### PR TITLE
[#11] pki: scripted steps to deploy certs

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,3 +22,12 @@ rules:
 settings:
   react:
     version: detect
+overrides:
+  - files:
+      - 'scripts/**/*.js'
+      - 'playwright/**/*.ts'
+    env:
+      node: true
+      es2021: true
+    rules:
+      '@typescript-eslint/no-var-requires': off

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 .devcontainer/dev.env
 playwright-report/
 test-results/
+
+# Prevent compiled files in src (TypeScript project)
+src/**/*.js
+src/**/*.js.map

--- a/README.md
+++ b/README.md
@@ -170,6 +170,124 @@ namespace. For example:
 Running `yarn i18n` updates the JSON files in the `locales` folder of the
 plugin template when adding or changing messages.
 
+## Certificate Management for BrokerService and BrokerApp
+
+This project includes a certificate management script for setting up the required PKI infrastructure
+to deploy BrokerService and BrokerApp resources.
+
+### Prerequisites
+
+Before using the certificate management script, ensure you have:
+
+- `kubectl` configured and connected to your cluster
+- `cert-manager` installed in your cluster
+- `trust-manager` installed in your cluster (with `secretTargets.enabled=true`)
+- Appropriate permissions to create cluster-wide resources
+- The ArkMQ operator installed in your cluster
+
+#### Installing the ArkMQ Operator
+
+Install the operator using Helm:
+
+```bash
+helm install my-arkmq-org-broker-operator \
+  oci://quay.io/arkmq-org/helm-charts/arkmq-org-broker-operator \
+  --version 0.0.0-dev.latest
+```
+
+#### Installing cert-manager
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.1/cert-manager.yaml
+kubectl wait deployment --for=condition=Available -n cert-manager --timeout=600s \
+  cert-manager cert-manager-cainjector cert-manager-webhook
+```
+
+#### Installing trust-manager
+
+```bash
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm upgrade trust-manager jetstack/trust-manager --install \
+  --namespace cert-manager \
+  --set secretTargets.enabled=true \
+  --set secretTargets.authorizedSecretsAll=true \
+  --wait
+```
+
+### Quick Start
+
+1. **Setup PKI Infrastructure** (one-time setup):
+
+   ```bash
+   yarn chain-of-trust setup
+   ```
+
+   This creates:
+   - Self-signed root ClusterIssuer and CA certificate
+   - CA-signed ClusterIssuer for issuing broker certificates
+   - Trust bundle that distributes the CA to all namespaces
+   - Operator certificate in the operator's namespace
+
+2. **Create BrokerService Certificate**:
+
+   ```bash
+   yarn chain-of-trust create-service-cert --name messaging-service --namespace my-namespace
+   ```
+
+   This creates a certificate with the correct DNS names for the BrokerService.
+
+3. **Create BrokerApp Certificate**:
+
+   ```bash
+   yarn chain-of-trust create-app-cert --name first-app --namespace my-namespace
+   ```
+
+   This creates a certificate for the BrokerApp to authenticate with the service.
+
+4. **Cleanup** (removes all PKI resources):
+
+   ```bash
+   yarn chain-of-trust cleanup
+   ```
+
+### Usage Examples
+
+**Setup with explicit namespace:**
+```bash
+yarn chain-of-trust setup --namespace my-operator-namespace
+```
+
+**Create certificates in different namespaces:**
+```bash
+# Service in namespace X
+yarn chain-of-trust create-service-cert --name messaging-service --namespace service-namespace
+
+# App in namespace Y
+yarn chain-of-trust create-app-cert --name first-app --namespace app-namespace
+```
+
+**Get help:**
+```bash
+yarn chain-of-trust --help
+```
+
+### What Gets Created
+
+The `setup` command creates:
+- `ClusterIssuer/root-issuer` - Self-signed root issuer
+- `Certificate/root-cert` (in cert-manager namespace) - Root CA certificate
+- `ClusterIssuer/broker-ca-issuer` - CA issuer for signing broker certificates
+- `Bundle/activemq-artemis-manager-ca` - Trust bundle distributed to all namespaces
+- `Certificate/activemq-artemis-manager-cert` - Operator certificate
+
+The `create-service-cert` command creates:
+- `Certificate/<service-name>-broker-cert` - Service certificate with proper DNS names
+- `Secret/<service-name>-broker-cert` - Secret containing the certificate
+
+The `create-app-cert` command creates:
+- `Certificate/<app-name>-app-cert` - App certificate
+- `Secret/<app-name>-app-cert` - Secret containing the certificate
+
 ## Linting
 
 This project adds prettier, eslint, and stylelint. Linting can be run with
@@ -187,7 +305,13 @@ best practice is to prefix your CSS classnames with your plugin name to avoid
 conflicts. Please don't disable these rules without understanding how they can
 break console styles!
 
-## latest
+## Testing
+
+### E2E Tests with Playwright
+
+This project includes Playwright E2E tests for UI testing and infrastructure validation.
+
+#### UI Tests
 
 With all prerequisites in place and the webpack server running:
 
@@ -222,6 +346,30 @@ KUBEADMIN_PASSWORD=kubeadmin yarn pw:test
 ```
 
 Runs tests in the terminal without opening a browser window.
+
+#### Certificate Management Tests
+
+The project includes E2E tests for the certificate management workflow:
+
+```bash
+# Run all tests (including certificate management)
+yarn pw:test
+
+# Run only certificate management tests
+yarn pw:test certificate-management
+```
+
+These tests validate:
+- PKI infrastructure setup
+- Certificate creation for BrokerService and BrokerApp
+- Resource deployment and readiness
+- Cleanup functionality
+
+**Note:** Certificate management tests require:
+- cert-manager installed
+- trust-manager installed
+- ArkMQ operator installed
+- Cluster access configured with kubectl
 
 ## References
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "pw:test": "playwright test",
     "pw:ui": "playwright test --ui",
     "pw:headed": "playwright test --headed",
-    "lint": "yarn eslint src integration-tests --fix && stylelint 'src/**/*.css' --allow-empty-input --fix",
+    "lint": "yarn eslint src scripts playwright --fix && stylelint 'src/**/*.css' --allow-empty-input --fix",
+    "chain-of-trust": "node scripts/chain-of-trust.js",
     "webpack": "node -r ts-node/register ./node_modules/.bin/webpack"
   },
   "devDependencies": {

--- a/playwright/e2e/certificate-management.spec.ts
+++ b/playwright/e2e/certificate-management.spec.ts
@@ -1,0 +1,233 @@
+import { test, expect } from '@playwright/test';
+import {
+  kubectl,
+  yarn,
+  waitForCondition,
+  waitForPod,
+  createNamespace,
+  deleteNamespace,
+  applyYaml,
+  secretExists,
+} from '../fixtures/k8s';
+
+const TEST_NAMESPACE = 'cert-mgmt-e2e-test';
+const SERVICE_NAME = 'test-messaging-service';
+const APP_NAME = 'test-app';
+
+test.describe('Certificate Management E2E', () => {
+  test.beforeAll(() => {
+    console.log('\n🧪 Starting Certificate Management E2E Tests\n');
+  });
+
+  test.afterAll(async () => {
+    // Cleanup test namespace
+    console.log('\n🧹 Cleaning up test namespace...');
+    deleteNamespace(TEST_NAMESPACE);
+
+    console.log('\n✅ E2E Tests Complete\n');
+  });
+
+  test('complete workflow: setup, deploy, and cleanup', async () => {
+    // Step 1: Setup PKI infrastructure
+    console.log('\n📦 Step 1: Setting up PKI infrastructure...');
+    const setupOutput = yarn('chain-of-trust setup', { timeout: 180000 });
+    expect(setupOutput).toContain('Chain of Trust Setup Complete');
+    expect(setupOutput).toContain('ClusterIssuer: root-issuer');
+    expect(setupOutput).toContain('ClusterIssuer: broker-ca-issuer');
+    expect(setupOutput).toContain('Bundle: activemq-artemis-manager-ca');
+    expect(setupOutput).toContain('Certificate: activemq-artemis-manager-cert');
+    expect(setupOutput).toContain('in default namespace');
+
+    // Verify ClusterIssuers are ready
+    const rootIssuer = kubectl(
+      `get clusterissuer root-issuer -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`,
+    );
+    expect(rootIssuer).toBe('True');
+
+    const caIssuer = kubectl(
+      `get clusterissuer broker-ca-issuer -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`,
+    );
+    expect(caIssuer).toBe('True');
+
+    // Verify operator certificate was created in default namespace
+    const operatorNamespace = 'default';
+    console.log(`  ✓ Operator certificate created in default namespace`);
+    expect(secretExists('activemq-artemis-manager-cert', operatorNamespace)).toBe(true);
+
+    // Step 2: Create test namespace
+    console.log('\n📦 Step 2: Creating test namespace...');
+    createNamespace(TEST_NAMESPACE);
+
+    // Step 3: Create BrokerService certificates
+    console.log('\n📦 Step 3: Creating BrokerService certificate...');
+    const serviceCertOutput = yarn(
+      `chain-of-trust create-service-cert --name ${SERVICE_NAME} --namespace ${TEST_NAMESPACE}`,
+      { timeout: 180000 },
+    );
+    expect(serviceCertOutput).toContain('BrokerService Certificate Created');
+    expect(serviceCertOutput).toContain(`${SERVICE_NAME}-broker-cert`);
+
+    // Verify certificates exist
+    expect(secretExists('activemq-artemis-manager-ca', TEST_NAMESPACE)).toBe(true);
+    expect(secretExists(`${SERVICE_NAME}-broker-cert`, TEST_NAMESPACE)).toBe(true);
+
+    // Step 4: Deploy BrokerService
+    console.log('\n📦 Step 4: Deploying BrokerService...');
+    const brokerServiceYaml = `
+apiVersion: arkmq.org/v1beta2
+kind: BrokerService
+metadata:
+  name: ${SERVICE_NAME}
+  namespace: ${TEST_NAMESPACE}
+  labels:
+    forWorkQueue: "true"
+spec:
+  resources:
+    limits:
+      memory: "256Mi"
+  env:
+    - name: JAVA_ARGS_APPEND
+      value: "-Dlog4j2.level=INFO"
+`;
+    applyYaml(brokerServiceYaml);
+
+    // Check BrokerService status before waiting for pod
+    console.log('\n⏳ Checking BrokerService status...');
+    await new Promise((resolve) => setTimeout(resolve, 10000)); // Wait for operator to process
+    const brokerStatus = kubectl(
+      `get brokerservice ${SERVICE_NAME} -n ${TEST_NAMESPACE} -o jsonpath='{.status.conditions[?(@.type=="Valid")].message}'`,
+    );
+    if (brokerStatus && brokerStatus.includes('failed')) {
+      throw new Error(`BrokerService validation failed: ${brokerStatus}`);
+    }
+
+    // Wait for broker pod to be running (longer timeout for CI image pulls)
+    console.log('\n⏳ Waiting for broker pod to be ready...');
+    await waitForPod(`${SERVICE_NAME}-ss-0`, TEST_NAMESPACE, 600000);
+
+    // Wait for BrokerService to be deployed
+    console.log('\n⏳ Waiting for BrokerService to be deployed...');
+    await waitForCondition(
+      'brokerservice',
+      SERVICE_NAME,
+      TEST_NAMESPACE,
+      'Deployed',
+      'True',
+      600000,
+    );
+
+    // Step 5: Create BrokerApp certificates
+    console.log('\n📦 Step 5: Creating BrokerApp certificate...');
+    const appCertOutput = yarn(
+      `chain-of-trust create-app-cert --name ${APP_NAME} --namespace ${TEST_NAMESPACE}`,
+      { timeout: 180000 },
+    );
+    expect(appCertOutput).toContain('BrokerApp Certificate Created');
+    expect(appCertOutput).toContain(`${APP_NAME}-app-cert`);
+
+    // Verify app certificate exists
+    expect(secretExists(`${APP_NAME}-app-cert`, TEST_NAMESPACE)).toBe(true);
+
+    // Step 6: Deploy BrokerApp
+    console.log('\n📦 Step 6: Deploying BrokerApp...');
+    const brokerAppYaml = `
+apiVersion: arkmq.org/v1beta2
+kind: BrokerApp
+metadata:
+  name: ${APP_NAME}
+  namespace: ${TEST_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      forWorkQueue: "true"
+  acceptor:
+    port: 61616
+  capabilities:
+  - producerOf:
+    - address: "APP.JOBS"
+  - consumerOf:
+    - address: "APP.JOBS"
+`;
+    applyYaml(brokerAppYaml);
+
+    // Wait for BrokerApp to be valid
+    console.log('\n⏳ Waiting for BrokerApp to be valid...');
+    await waitForCondition('brokerapp', APP_NAME, TEST_NAMESPACE, 'Valid', 'True', 120000);
+
+    // Verify binding secret was created
+    console.log('\n✓ Verifying app binding secret...');
+    expect(secretExists(`${APP_NAME}-binding-secret`, TEST_NAMESPACE)).toBe(true);
+
+    // Step 7: Verify broker is functional
+    console.log('\n📦 Step 7: Verifying broker is active...');
+    const brokerLogs = kubectl(`logs ${SERVICE_NAME}-ss-0 -n ${TEST_NAMESPACE}`, {
+      timeout: 30000,
+    });
+
+    // Check for broker started message
+    expect(brokerLogs).toContain('AMQ221007');
+    console.log('  ✓ Broker is active (AMQ221007 found in logs)');
+
+    // Step 8: Verify all expected secrets exist
+    console.log('\n📦 Step 8: Verifying all certificates and secrets...');
+    const secrets = kubectl(`get secrets -n ${TEST_NAMESPACE} -o json`);
+    const secretsJson = JSON.parse(secrets) as {
+      items: Array<{ metadata: { name: string } }>;
+    };
+    const secretNames = secretsJson.items.map((s) => s.metadata.name);
+
+    expect(secretNames).toContain('activemq-artemis-manager-ca');
+    // Operator cert is in default namespace (hardcoded in operator)
+    expect(secretExists('activemq-artemis-manager-cert', 'default')).toBe(true);
+    expect(secretNames).toContain(`${SERVICE_NAME}-broker-cert`);
+    expect(secretNames).toContain(`${APP_NAME}-app-cert`);
+    expect(secretNames).toContain(`${APP_NAME}-binding-secret`);
+
+    // Verify binding secret has correct keys
+    const bindingSecret = kubectl(
+      `get secret ${APP_NAME}-binding-secret -n ${TEST_NAMESPACE} -o jsonpath='{.data}'`,
+    );
+    const bindingData = JSON.parse(bindingSecret);
+    expect(bindingData).toHaveProperty('uri');
+    expect(bindingData).toHaveProperty('host');
+    expect(bindingData).toHaveProperty('port');
+
+    console.log('\n✅ All verifications passed!');
+    console.log('\n📊 Summary:');
+    console.log('  ✓ PKI infrastructure setup');
+    console.log('  ✓ Operator certificate created in default namespace');
+    console.log('  ✓ BrokerService certificate created');
+    console.log('  ✓ BrokerApp certificate created');
+    console.log('  ✓ BrokerService deployed (Deployed=True)');
+    console.log('  ✓ BrokerApp deployed (Valid=True)');
+    console.log('  ✓ Broker pod is active (AMQ221007)');
+    console.log('  ✓ All required secrets exist');
+    console.log('  ✓ Binding secret contains connection details');
+  });
+
+  test('cleanup removes all PKI resources', async () => {
+    console.log('\n🧹 Testing cleanup functionality...');
+
+    // Run cleanup
+    const cleanupOutput = yarn('chain-of-trust cleanup', { timeout: 180000 });
+    expect(cleanupOutput).toContain('Cleanup complete');
+
+    // Wait a bit for resources to be deleted
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+
+    // Verify ClusterIssuers are deleted
+    const rootIssuerExists = kubectl('get clusterissuer root-issuer', { ignoreError: true });
+    expect(rootIssuerExists).toBe('');
+
+    const caIssuerExists = kubectl('get clusterissuer broker-ca-issuer', { ignoreError: true });
+    expect(caIssuerExists).toBe('');
+
+    // Verify Bundle is deleted
+    const bundleExists = kubectl('get bundle activemq-artemis-manager-ca -n cert-manager', {
+      ignoreError: true,
+    });
+    expect(bundleExists).toBe('');
+
+    console.log('\n✅ Cleanup verified successfully');
+  });
+});

--- a/playwright/e2e/smoke.spec.ts
+++ b/playwright/e2e/smoke.spec.ts
@@ -12,9 +12,7 @@ test.describe('Console login smoke', () => {
 });
 
 test.describe('Navigate to the example page', () => {
-  test('Logs in and navigate to the example page', async ({
-    page,
-  }) => {
+  test('Logs in and navigate to the example page', async ({ page }) => {
     // Login
     await login(page, username, password);
 
@@ -30,4 +28,3 @@ test.describe('Navigate to the example page', () => {
     ).toBeVisible({ timeout: 30000 });
   });
 });
-

--- a/playwright/fixtures/auth.ts
+++ b/playwright/fixtures/auth.ts
@@ -31,4 +31,3 @@ export async function login(page: Page, username: string, password: string) {
   // Wait for the page to be fully loaded and interactive
   await page.waitForLoadState('networkidle');
 }
-

--- a/playwright/fixtures/k8s.ts
+++ b/playwright/fixtures/k8s.ts
@@ -1,0 +1,182 @@
+import { execSync } from 'child_process';
+
+/**
+ * Execute a kubectl command
+ */
+export function kubectl(
+  args: string,
+  options: { timeout?: number; ignoreError?: boolean } = {},
+): string {
+  try {
+    const result = execSync(`kubectl ${args}`, {
+      encoding: 'utf-8',
+      timeout: options.timeout || 60000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return result.trim();
+  } catch (error: unknown) {
+    if (options.ignoreError) {
+      return '';
+    }
+    const err = error as Error & { stderr?: string };
+    throw new Error(`kubectl ${args} failed: ${err.message}\n${err.stderr || ''}`);
+  }
+}
+
+/**
+ * Execute a yarn command
+ */
+export function yarn(args: string, options: { timeout?: number } = {}): string {
+  const result = execSync(`yarn ${args}`, {
+    encoding: 'utf-8',
+    timeout: options.timeout || 120000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return result.trim();
+}
+
+/**
+ * Wait for a resource to have a specific condition
+ */
+export async function waitForCondition(
+  resourceType: string,
+  resourceName: string,
+  namespace: string,
+  conditionType: string,
+  expectedStatus = 'True',
+  timeoutMs = 300000,
+): Promise<boolean> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const conditions = kubectl(
+        `get ${resourceType} ${resourceName} -n ${namespace} -o jsonpath='{.status.conditions}'`,
+        { ignoreError: true },
+      );
+
+      if (conditions) {
+        const conditionsArray = JSON.parse(conditions) as Array<{
+          type: string;
+          status: string;
+          reason?: string;
+        }>;
+        const condition = conditionsArray.find((c) => c.type === conditionType);
+
+        if (condition && condition.status === expectedStatus) {
+          console.log(
+            `✓ ${resourceType}/${resourceName} condition ${conditionType}=${expectedStatus}`,
+          );
+          return true;
+        }
+
+        // Log current status for debugging
+        if (condition) {
+          console.log(
+            `  ${resourceType}/${resourceName} ${conditionType}: ${condition.status} (${condition.reason})`,
+          );
+        }
+      }
+    } catch (error) {
+      // Resource might not exist yet, continue waiting
+    }
+
+    // Wait 5 seconds before checking again
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+
+  throw new Error(
+    `Timeout waiting for ${resourceType}/${resourceName} condition ${conditionType}=${expectedStatus} in namespace ${namespace}`,
+  );
+}
+
+/**
+ * Wait for a pod to be ready
+ */
+export async function waitForPod(
+  podName: string,
+  namespace: string,
+  timeoutMs = 300000,
+): Promise<boolean> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const status = kubectl(`get pod ${podName} -n ${namespace} -o jsonpath='{.status.phase}'`, {
+        ignoreError: true,
+      });
+
+      if (status === 'Running') {
+        // Check if containers are ready
+        const ready = kubectl(
+          `get pod ${podName} -n ${namespace} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`,
+          { ignoreError: true },
+        );
+
+        if (ready === 'True') {
+          console.log(`✓ Pod ${podName} is ready`);
+          return true;
+        }
+      }
+
+      console.log(`  Pod ${podName} status: ${status}`);
+    } catch (error) {
+      // Pod might not exist yet
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+
+  throw new Error(`Timeout waiting for pod ${podName} in namespace ${namespace}`);
+}
+
+/**
+ * Create a namespace (idempotent)
+ */
+export function createNamespace(name: string): void {
+  kubectl(`create namespace ${name}`, { ignoreError: true });
+  console.log(`✓ Namespace ${name} ready`);
+}
+
+/**
+ * Delete a namespace
+ */
+export function deleteNamespace(name: string): void {
+  kubectl(`delete namespace ${name} --ignore-not-found=true`, { timeout: 120000 });
+  console.log(`✓ Namespace ${name} deleted`);
+}
+
+/**
+ * Apply YAML from stdin
+ */
+export function applyYaml(yaml: string): void {
+  execSync('kubectl apply -f -', {
+    input: yaml,
+    encoding: 'utf-8',
+    timeout: 60000,
+  });
+}
+
+/**
+ * Get resource as JSON
+ */
+export function getResource(
+  resourceType: string,
+  resourceName: string,
+  namespace: string,
+): Record<string, unknown> {
+  const json = kubectl(`get ${resourceType} ${resourceName} -n ${namespace} -o json`);
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+/**
+ * Check if a secret exists
+ */
+export function secretExists(secretName: string, namespace: string): boolean {
+  try {
+    kubectl(`get secret ${secretName} -n ${namespace}`);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/chain-of-trust.js
+++ b/scripts/chain-of-trust.js
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+/**
+ * Chain of Trust Management
+ *
+ * This script manages PKI infrastructure for the ArkMQ
+ * BrokerService and BrokerApp CRDs.
+ *
+ * Usage:
+ *   yarn chain-of-trust setup [options]
+ *   yarn chain-of-trust create-service-cert --name <service-name> --namespace <namespace>
+ *   yarn chain-of-trust create-app-cert --name <app-name> --namespace <namespace>
+ *   yarn chain-of-trust cleanup [options]
+ *
+ * Commands:
+ *   setup                       Create PKI infrastructure (root CA, issuers, trust bundle, operator cert)
+ *   create-service-cert         Create certificate for a BrokerService
+ *   create-app-cert             Create certificate for a BrokerApp
+ *   cleanup                     Remove PKI infrastructure
+ *
+ * Options:
+ *   --namespace <name>          Target namespace (auto-detected from cluster if omitted for setup)
+ *   --name <name>               Resource name (required for create-service-cert and create-app-cert)
+ *   --help                      Show this help message
+ */
+
+const { setupCompletePKI, createServiceCertificate, createAppCertificate } = require('./setup-pki');
+const { exec } = require('child_process');
+const { promisify } = require('util');
+
+const execAsync = promisify(exec);
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const command = args[0];
+let namespace = null;
+let name = null;
+
+function showHelp() {
+  console.log(`
+Chain of Trust Management
+
+This script manages PKI infrastructure for the ArkMQ
+BrokerService and BrokerApp CRDs.
+
+Usage:
+  yarn chain-of-trust setup
+  yarn chain-of-trust create-service-cert --name <service-name> --namespace <namespace>
+  yarn chain-of-trust create-app-cert --name <app-name> --namespace <namespace>
+  yarn chain-of-trust cleanup
+
+Commands:
+  setup                       Create PKI infrastructure (root CA, issuers, trust bundle, operator cert)
+  create-service-cert         Create certificate for a BrokerService
+  create-app-cert             Create certificate for a BrokerApp
+  cleanup                     Remove PKI infrastructure
+
+Options:
+  --namespace <name>          Target namespace (required for create-service-cert and create-app-cert)
+  --name <name>               Resource name (required for create-service-cert and create-app-cert)
+  --help                      Show this help message
+
+Examples:
+  # Setup the PKI infrastructure (creates operator cert in 'default' namespace)
+  yarn chain-of-trust setup
+
+  # Create certificate for a BrokerService
+  yarn chain-of-trust create-service-cert --name messaging-service --namespace service-namespace
+
+  # Create a certificate for a BrokerApp
+  yarn chain-of-trust create-app-cert --name first-app --namespace app-namespace
+
+  # Cleanup all PKI resources
+  yarn chain-of-trust cleanup
+
+Note: The operator certificate is always created in the 'default' namespace where
+      the operator expects to find it (hardcoded DefaultOperatorCertSecretName).
+`);
+  process.exit(0);
+}
+
+// Parse options
+for (let i = 1; i < args.length; i++) {
+  if (args[i] === '--namespace' && args[i + 1]) {
+    namespace = args[i + 1];
+    i++;
+  } else if (args[i] === '--name' && args[i + 1]) {
+    name = args[i + 1];
+    i++;
+  } else if (args[i] === '--help') {
+    showHelp();
+  }
+}
+
+const validCommands = ['setup', 'create-service-cert', 'create-app-cert', 'cleanup'];
+if (!command || !validCommands.includes(command)) {
+  console.error(`Error: Please specify a valid command (${validCommands.join(', ')})`);
+  showHelp();
+}
+
+const resourceNames = {
+  rootIssuer: 'root-issuer',
+  rootCert: 'root-cert',
+  rootSecret: 'arkmq-root-cert-secret',
+  caIssuer: 'broker-ca-issuer',
+  bundle: 'activemq-artemis-manager-ca',
+  operatorCert: 'activemq-artemis-manager-cert',
+};
+
+/**
+ * Helper: Delete certificates matching a pattern across all namespaces
+ */
+async function deleteCertificatePattern(pattern) {
+  try {
+    await execAsync(
+      `kubectl get certificates -A -o json 2>/dev/null | jq -r '.items[] | select(.metadata.name | contains("${pattern}")) | "\\(.metadata.namespace) \\(.metadata.name)"' | xargs -r -L1 sh -c 'kubectl delete certificate $1 -n $0 --ignore-not-found=true' || true`,
+    );
+  } catch (error) {
+    // Ignore errors during cleanup
+  }
+}
+
+/**
+ * Helper: Delete secrets matching a pattern across all namespaces
+ */
+async function deleteSecretPattern(pattern) {
+  try {
+    await execAsync(
+      `kubectl get secrets -A -o json 2>/dev/null | jq -r '.items[] | select(.metadata.name | contains("${pattern}")) | "\\(.metadata.namespace) \\(.metadata.name)"' | xargs -r -L1 sh -c 'kubectl delete secret $1 -n $0 --ignore-not-found=true' || true`,
+    );
+  } catch (error) {
+    // Ignore errors during cleanup
+  }
+}
+
+/**
+ * Setup function - creates PKI infrastructure
+ */
+async function setup() {
+  console.log('\n🔐 Setting up Chain of Trust for ArkMQ\n');
+
+  try {
+    const createdResources = await setupCompletePKI();
+
+    // Success summary
+    console.log('\n✅ Chain of Trust Setup Complete!\n');
+    console.log('Created resources:');
+    console.log(`  ✓ ClusterIssuer: ${createdResources.rootIssuer} (self-signed)`);
+    console.log(`  ✓ Certificate: ${createdResources.rootCert} (in cert-manager namespace)`);
+    console.log(`  ✓ ClusterIssuer: ${createdResources.caIssuer} (CA-signed)`);
+    console.log(`  ✓ Bundle: ${createdResources.bundle} (distributes to all namespaces)`);
+    console.log(
+      `  ✓ Certificate: ${createdResources.operatorCert} (in ${createdResources.operatorCertNamespace} namespace)`,
+    );
+    console.log('\nYou can now:');
+    console.log(`  1. Create BrokerService and BrokerApp certificates using:`);
+    console.log(
+      `     yarn chain-of-trust create-service-cert --name <service-name> --namespace <namespace>`,
+    );
+    console.log(
+      `     yarn chain-of-trust create-app-cert --name <app-name> --namespace <namespace>`,
+    );
+    console.log(
+      `  2. The trust bundle "${createdResources.bundle}" will automatically appear in all namespaces\n`,
+    );
+  } catch (error) {
+    console.error('\n❌ Error during setup:', error.message);
+    console.error('\nMake sure you have:');
+    console.error('  - kubectl configured and connected to your cluster');
+    console.error('  - cert-manager installed in your cluster');
+    console.error('  - trust-manager installed in your cluster');
+    console.error('  - Appropriate permissions to create cluster-wide resources\n');
+    process.exit(1);
+  }
+}
+
+/**
+ * Create Service Certificate function
+ */
+async function createServiceCert() {
+  if (!name) {
+    console.error('\n❌ Error: --name is required for create-service-cert');
+    showHelp();
+  }
+  if (!namespace) {
+    console.error('\n❌ Error: --namespace is required for create-service-cert');
+    showHelp();
+  }
+
+  console.log(`\n📜 Creating certificates for BrokerService '${name}' in namespace ${namespace}\n`);
+
+  try {
+    const result = await createServiceCertificate(name, namespace, resourceNames.caIssuer);
+
+    console.log('\n✅ BrokerService Certificate Created!\n');
+    console.log(`Created resources:`);
+    console.log(`  ✓ Certificate: ${result.certName} (service)`);
+    console.log(`  ✓ Secret: ${result.secretName} (service)`);
+    console.log(`\nYou can now deploy your BrokerService '${name}' in namespace ${namespace}\n`);
+  } catch (error) {
+    console.error('\n❌ Error creating service certificate:', error.message);
+    console.error('\nMake sure:');
+    console.error('  - PKI infrastructure is set up (run "yarn chain-of-trust setup" first)');
+    console.error('  - The namespace exists');
+    console.error('  - kubectl is configured correctly\n');
+    process.exit(1);
+  }
+}
+
+/**
+ * Create App Certificate function
+ */
+async function createAppCert() {
+  if (!name) {
+    console.error('\n❌ Error: --name is required for create-app-cert');
+    showHelp();
+  }
+  if (!namespace) {
+    console.error('\n❌ Error: --namespace is required for create-app-cert');
+    showHelp();
+  }
+
+  console.log(`\n📜 Creating certificate for BrokerApp '${name}' in namespace ${namespace}\n`);
+
+  try {
+    const result = await createAppCertificate(name, namespace, resourceNames.caIssuer);
+
+    console.log('\n✅ BrokerApp Certificate Created!\n');
+    console.log(`Created resources:`);
+    console.log(`  ✓ Certificate: ${result.certName}`);
+    console.log(`  ✓ Secret: ${result.secretName}`);
+    console.log(`\nYou can now deploy your BrokerApp '${name}' in namespace ${namespace}\n`);
+  } catch (error) {
+    console.error('\n❌ Error creating app certificate:', error.message);
+    console.error('\nMake sure:');
+    console.error('  - PKI infrastructure is set up (run "yarn chain-of-trust setup" first)');
+    console.error('  - The namespace exists');
+    console.error('  - kubectl is configured correctly\n');
+    process.exit(1);
+  }
+}
+
+/**
+ * Cleanup function - removes PKI infrastructure
+ */
+async function cleanup() {
+  const operatorCertNamespace = 'default';
+
+  console.log('\n🧹 Cleaning up Chain of Trust Resources\n');
+
+  try {
+    // Delete Bundle
+    console.log('  Deleting Bundle...');
+    await execAsync(
+      `kubectl delete bundle ${resourceNames.bundle} -n cert-manager --ignore-not-found=true`,
+    );
+
+    // Delete operator certificate from default namespace
+    console.log(`  Deleting operator certificate from ${operatorCertNamespace}...`);
+    await execAsync(
+      `kubectl delete certificate ${resourceNames.operatorCert} -n ${operatorCertNamespace} --ignore-not-found=true`,
+    );
+    await execAsync(
+      `kubectl delete secret ${resourceNames.operatorCert} -n ${operatorCertNamespace} --ignore-not-found=true`,
+    );
+
+    // Delete all broker certificates (service and app) from all namespaces
+    console.log('  Deleting all BrokerService certificates...');
+    await deleteCertificatePattern('broker-cert');
+    await deleteSecretPattern('broker-cert');
+
+    console.log('  Deleting all BrokerApp certificates...');
+    await deleteCertificatePattern('app-cert');
+    await deleteSecretPattern('app-cert');
+
+    // Delete ClusterIssuers
+    console.log('  Deleting ClusterIssuers...');
+    await execAsync(
+      `kubectl delete clusterissuer ${resourceNames.rootIssuer} ${resourceNames.caIssuer} --ignore-not-found=true`,
+    );
+
+    // Delete root CA certificate and secret
+    console.log('  Deleting root CA resources...');
+    await execAsync(
+      `kubectl delete certificate ${resourceNames.rootCert} -n cert-manager --ignore-not-found=true`,
+    );
+    await execAsync(
+      `kubectl delete secret ${resourceNames.rootSecret} -n cert-manager --ignore-not-found=true`,
+    );
+
+    console.log('\n✅ Cleanup complete!\n');
+    console.log('Removed resources:');
+    console.log(`  ✓ Bundle: ${resourceNames.bundle}`);
+    console.log(
+      `  ✓ Operator certificate (${resourceNames.operatorCert} from ${operatorCertNamespace})`,
+    );
+    console.log(`  ✓ All BrokerService certificates and secrets (pattern: *broker-cert*)`);
+    console.log(`  ✓ All BrokerApp certificates and secrets (pattern: *app-cert*)`);
+    console.log(`  ✓ ClusterIssuers: ${resourceNames.rootIssuer}, ${resourceNames.caIssuer}`);
+    console.log(`  ✓ Certificate: ${resourceNames.rootCert} (from cert-manager)`);
+    console.log(`  ✓ Secret: ${resourceNames.rootSecret} (from cert-manager)\n`);
+  } catch (error) {
+    console.error('\n❌ Error during cleanup:', error.message);
+    console.error('\nSome resources may not have been deleted. Check manually with kubectl.\n');
+    process.exit(1);
+  }
+}
+
+// Run the appropriate command
+if (command === 'setup') {
+  setup();
+} else if (command === 'create-service-cert') {
+  createServiceCert();
+} else if (command === 'create-app-cert') {
+  createAppCert();
+} else if (command === 'cleanup') {
+  cleanup();
+}

--- a/scripts/setup-pki.js
+++ b/scripts/setup-pki.js
@@ -1,0 +1,420 @@
+/**
+ * Shared PKI Setup Functions
+ *
+ * This module provides reusable functions for setting up cert-manager PKI infrastructure
+ * for ArkMQ BrokerService and BrokerApp resources.
+ * Based on the operator tutorial: docs/tutorials/service_app_crd_round_trip.md
+ */
+
+const { exec } = require('child_process');
+const { promisify } = require('util');
+
+const execAsync = promisify(exec);
+
+/**
+ * Apply YAML content using kubectl
+ */
+async function applyYaml(yaml) {
+  const escapedYaml = yaml.replace(/'/g, "'\\''");
+  const { stdout, stderr } = await execAsync(`echo '${escapedYaml}' | kubectl apply -f -`);
+  if (stderr && !stderr.includes('created') && !stderr.includes('configured')) {
+    console.error('kubectl stderr:', stderr);
+  }
+  if (stdout) {
+    console.log(stdout.trim());
+  }
+}
+
+/**
+ * Wait for a ClusterIssuer to be Ready
+ */
+async function waitForClusterIssuerReady(issuerName, timeoutMs = 300000) {
+  console.log(`⏳ Waiting for ClusterIssuer ${issuerName} to be Ready...`);
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const { stdout } = await execAsync(
+        `kubectl get clusterissuer ${issuerName} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`,
+      );
+      if (stdout.trim() === 'True') {
+        console.log(`✓ ClusterIssuer ${issuerName} is Ready`);
+        return;
+      }
+    } catch (error) {
+      // Issuer might not exist yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  throw new Error(`Timeout waiting for ClusterIssuer ${issuerName} to be Ready`);
+}
+
+/**
+ * Wait for a Certificate to be Ready
+ */
+async function waitForCertificate(namespace, certName, timeoutMs = 300000) {
+  console.log(`⏳ Waiting for Certificate ${certName} in namespace ${namespace} to be Ready...`);
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const { stdout } = await execAsync(
+        `kubectl get certificate ${certName} -n ${namespace} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`,
+      );
+      if (stdout.trim() === 'True') {
+        console.log(`✓ Certificate ${certName} is Ready`);
+        return;
+      }
+    } catch (error) {
+      // Certificate might not exist yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  throw new Error(
+    `Timeout waiting for Certificate ${certName} in namespace ${namespace} to be Ready`,
+  );
+}
+
+/**
+ * Wait for a secret to exist in a namespace
+ */
+async function waitForSecret(namespace, secretName, timeoutMs = 60000) {
+  console.log(`⏳ Waiting for Secret ${secretName} in namespace ${namespace}...`);
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      await execAsync(`kubectl get secret ${secretName} -n ${namespace}`);
+      console.log(`✓ Secret ${secretName} exists in namespace ${namespace}`);
+      return; // Secret exists
+    } catch (error) {
+      // Secret doesn't exist yet
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+
+  throw new Error(`Timeout waiting for secret ${secretName} in namespace ${namespace}`);
+}
+
+/**
+ * Wait for a Bundle to be Synced
+ */
+async function waitForBundle(bundleName, timeoutMs = 300000) {
+  console.log(`⏳ Waiting for Bundle ${bundleName} to be Synced...`);
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const { stdout } = await execAsync(
+        `kubectl get bundle ${bundleName} -n cert-manager -o jsonpath='{.status.conditions[?(@.type=="Synced")].status}'`,
+      );
+      if (stdout.trim() === 'True') {
+        console.log(`✓ Bundle ${bundleName} is Synced`);
+        return;
+      }
+    } catch (error) {
+      // Bundle might not exist yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  throw new Error(`Timeout waiting for Bundle ${bundleName} to be Synced`);
+}
+
+/**
+ * Creates the cluster-level cert-manager infrastructure
+ * This includes:
+ * - Self-signed root ClusterIssuer
+ * - Root CA Certificate in cert-manager namespace
+ * - CA ClusterIssuer (signed by root CA)
+ *
+ * @returns {Promise<object>} Resource names that were created
+ */
+async function createClusterInfrastructure() {
+  console.log(`📦 Creating cluster PKI infrastructure...`);
+
+  const resourceNames = {
+    rootIssuer: 'root-issuer',
+    rootCert: 'root-cert',
+    rootSecret: 'arkmq-root-cert-secret',
+    caIssuer: 'broker-ca-issuer',
+  };
+
+  // Step 1: Create self-signed root issuer
+  console.log('📦 Step 1: Creating self-signed root ClusterIssuer...');
+  const rootIssuerYaml = `
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${resourceNames.rootIssuer}
+spec:
+  selfSigned: {}
+`;
+  await applyYaml(rootIssuerYaml);
+  await waitForClusterIssuerReady(resourceNames.rootIssuer);
+
+  // Step 2: Create root CA certificate
+  console.log('📦 Step 2: Creating root CA certificate...');
+  const rootCACertYaml = `
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${resourceNames.rootCert}
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: arkmq.root.ca
+  secretName: ${resourceNames.rootSecret}
+  issuerRef:
+    name: ${resourceNames.rootIssuer}
+    kind: ClusterIssuer
+`;
+  await applyYaml(rootCACertYaml);
+  await waitForCertificate('cert-manager', resourceNames.rootCert);
+
+  // Step 3: Create CA issuer
+  console.log('📦 Step 3: Creating CA-signed ClusterIssuer...');
+  const caIssuerYaml = `
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${resourceNames.caIssuer}
+spec:
+  ca:
+    secretName: ${resourceNames.rootSecret}
+`;
+  await applyYaml(caIssuerYaml);
+  await waitForClusterIssuerReady(resourceNames.caIssuer);
+
+  console.log('✅ Cluster infrastructure created successfully');
+  return resourceNames;
+}
+
+/**
+ * Creates trust bundle only (operator cert is created per-namespace with resources)
+ *
+ * @param {string} rootSecretName - Name of the root CA secret (from createClusterInfrastructure)
+ * @returns {Promise<object>} Resource names that were created
+ */
+async function createTrustBundle(rootSecretName) {
+  console.log(`📦 Creating trust bundle...`);
+
+  const bundleName = 'activemq-artemis-manager-ca';
+
+  const bundleYaml = `
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: ${bundleName}
+  namespace: cert-manager
+spec:
+  sources:
+  - secret:
+      name: ${rootSecretName}
+      key: "tls.crt"
+  target:
+    secret:
+      key: "ca.pem"
+`;
+  await applyYaml(bundleYaml);
+  await waitForBundle(bundleName);
+
+  console.log('✅ Trust bundle created successfully');
+
+  return {
+    bundle: bundleName,
+  };
+}
+
+/**
+ * Creates operator certificate in a specific namespace
+ *
+ * @param {string} namespace - Namespace where the operator cert should be created
+ * @param {string} caIssuerName - Name of the CA issuer (from createClusterInfrastructure)
+ * @returns {Promise<object>} Resource names that were created
+ */
+async function createOperatorCert(namespace, caIssuerName) {
+  console.log(`📦 Creating operator certificate in namespace: ${namespace}...`);
+
+  const operatorCertName = 'activemq-artemis-manager-cert';
+
+  // Wait for the CA secret to appear in the namespace
+  const bundleName = 'activemq-artemis-manager-ca';
+  console.log(`⏳ Waiting for CA secret to be distributed to namespace ${namespace}...`);
+  await waitForSecret(namespace, bundleName);
+
+  // Create operator certificate
+  const operatorCertYaml = `
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${operatorCertName}
+  namespace: ${namespace}
+spec:
+  secretName: ${operatorCertName}
+  commonName: arkmq-org-broker-operator
+  issuerRef:
+    name: ${caIssuerName}
+    kind: ClusterIssuer
+`;
+  await applyYaml(operatorCertYaml);
+  await waitForCertificate(namespace, operatorCertName);
+
+  console.log(`✅ Operator certificate created in namespace ${namespace}`);
+
+  return {
+    operatorCert: operatorCertName,
+  };
+}
+
+/**
+ * Creates a certificate for a BrokerService
+ *
+ * @param {string} serviceName - Name of the BrokerService
+ * @param {string} namespace - Namespace where the BrokerService will be deployed
+ * @param {string} caIssuerName - Name of the CA issuer to use for signing
+ * @returns {Promise<object>} Resource names that were created
+ */
+async function createServiceCertificate(serviceName, namespace, caIssuerName) {
+  console.log(
+    `📦 Creating certificate for BrokerService '${serviceName}' in namespace ${namespace}...`,
+  );
+
+  // Wait for the CA secret to appear in the namespace (distributed by trust-manager)
+  const bundleName = 'activemq-artemis-manager-ca';
+  console.log(`⏳ Waiting for CA secret to be distributed to namespace ${namespace}...`);
+  await waitForSecret(namespace, bundleName);
+
+  const certName = `${serviceName}-broker-cert`;
+
+  const certYaml = `
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${certName}
+  namespace: ${namespace}
+spec:
+  secretName: ${certName}
+  commonName: ${serviceName}
+  dnsNames:
+  - ${serviceName}
+  - '*.${serviceName}-hdls-svc.${namespace}.svc.cluster.local'
+  issuerRef:
+    name: ${caIssuerName}
+    kind: ClusterIssuer
+`;
+  await applyYaml(certYaml);
+  await waitForCertificate(namespace, certName);
+
+  console.log(`✅ Certificate ${certName} created successfully for BrokerService`);
+
+  return {
+    certName: certName,
+    secretName: certName,
+  };
+}
+
+/**
+ * Creates a certificate for a BrokerApp
+ *
+ * @param {string} appName - Name of the BrokerApp
+ * @param {string} namespace - Namespace where the BrokerApp will be deployed
+ * @param {string} caIssuerName - Name of the CA issuer to use for signing
+ * @returns {Promise<object>} Resource names that were created
+ */
+async function createAppCertificate(appName, namespace, caIssuerName) {
+  console.log(`📦 Creating certificate for BrokerApp '${appName}' in namespace ${namespace}...`);
+
+  const certName = `${appName}-app-cert`;
+
+  const certYaml = `
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${certName}
+  namespace: ${namespace}
+spec:
+  secretName: ${certName}
+  commonName: ${appName}
+  issuerRef:
+    name: ${caIssuerName}
+    kind: ClusterIssuer
+`;
+  await applyYaml(certYaml);
+  await waitForCertificate(namespace, certName);
+
+  console.log(`✅ Certificate ${certName} created successfully for BrokerApp`);
+
+  return {
+    certName: certName,
+    secretName: certName,
+  };
+}
+
+/**
+ * Creates the complete PKI infrastructure (cluster infra + trust bundle + operator cert)
+ * Note: The operator cert is always created in the 'default' namespace where the operator
+ * is hardcoded to look for it (see DefaultOperatorCertSecretName in operator code)
+ *
+ * @returns {Promise<object>} All created resource names
+ */
+async function setupCompletePKI() {
+  const operatorCertNamespace = 'default';
+  const clusterResources = await createClusterInfrastructure();
+  const trustResources = await createTrustBundle(clusterResources.rootSecret);
+  const operatorResources = await createOperatorCert(
+    operatorCertNamespace,
+    clusterResources.caIssuer,
+  );
+
+  return {
+    ...clusterResources,
+    ...trustResources,
+    ...operatorResources,
+    operatorCertNamespace,
+  };
+}
+
+const OPERATOR_POD_LABEL = 'app.kubernetes.io/name=arkmq-org-broker-operator';
+
+/**
+ * Auto-detect the namespace where the ArkMQ operator is running
+ * by querying for pods with the operator's well-known label.
+ *
+ * @param {string} [fallback='default'] - Namespace to return if detection fails
+ * @returns {Promise<string>} The detected operator namespace
+ */
+async function detectOperatorNamespace(fallback = 'default') {
+  try {
+    const { stdout } = await execAsync(
+      `kubectl get pods -A -l ${OPERATOR_POD_LABEL} -o jsonpath='{.items[0].metadata.namespace}'`,
+    );
+    const ns = stdout.trim().replace(/^'|'$/g, '');
+    if (ns) {
+      console.log(`✓ Detected operator namespace: ${ns}`);
+      return ns;
+    }
+  } catch (error) {
+    // Detection failed, fall through to fallback
+  }
+  console.log(`⚠️  Could not detect operator namespace, falling back to "${fallback}"`);
+  return fallback;
+}
+
+module.exports = {
+  applyYaml,
+  waitForClusterIssuerReady,
+  waitForCertificate,
+  waitForSecret,
+  waitForBundle,
+  createClusterInfrastructure,
+  createTrustBundle,
+  createOperatorCert,
+  createServiceCertificate,
+  createAppCertificate,
+  setupCompletePKI,
+  detectOperatorNamespace,
+  execAsync,
+};


### PR DESCRIPTION
To deploy a broker app and a broker service, we need to have a PKI and certificates at disposal. The operator is not yet generating these. While we wait for the oeprator to take care of generating these resources, as developers we can make use of these scripts.

They are also tested in an E2E scenario, where the test:
- sets the PKI
- generate the certs
- deploys app and service
- make sure status is green