### PR TITLE
[#14] Enable Prometheus Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,76 @@ best practice is to prefix your CSS classnames with your plugin name to avoid
 conflicts. Please don't disable these rules without understanding how they can
 break console styles!
 
+## Prometheus Monitoring
+
+This project includes a script to manage Prometheus user workload monitoring in OpenShift and other Kubernetes platforms.
+
+### Commands
+
+**Enable user workload monitoring:**
+
+```bash
+yarn prometheus-config enable
+```
+
+Applies the `cluster-monitoring-config` ConfigMap to enable user workload monitoring.
+
+**Verify monitoring setup:**
+
+```bash
+yarn prometheus-config verify
+```
+
+Waits for the `openshift-user-workload-monitoring` namespace to exist and for all monitoring pods to be ready.
+
+**Disable monitoring (cleanup):**
+
+```bash
+yarn prometheus-config disable
+```
+
+Removes the `cluster-monitoring-config` ConfigMap to disable user workload monitoring.
+
+### Configuration for Non-OpenShift Platforms
+
+The script defaults to OpenShift namespace names, but can be customized using environment variables:
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `MONITORING_NAMESPACE` | `openshift-user-workload-monitoring` | Namespace where user workload monitoring pods run |
+| `CLUSTER_MONITORING_NAMESPACE` | `openshift-monitoring` | Namespace where cluster monitoring config is stored |
+| `MONITORING_CONFIG` | `cluster-monitoring-config` | Name of the ConfigMap that enables monitoring |
+
+**Example for custom platforms:**
+
+```bash
+MONITORING_NAMESPACE=monitoring \
+CLUSTER_MONITORING_NAMESPACE=kube-monitoring \
+MONITORING_CONFIG=monitoring-config \
+yarn prometheus-config enable
+```
+
+### Manual Configuration
+
+The script applies this ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+```
+
+And verifies by checking:
+
+```bash
+kubectl -n openshift-user-workload-monitoring get pods
+```
+
 ## Testing
 
 ### E2E Tests with Playwright
@@ -346,6 +416,22 @@ KUBEADMIN_PASSWORD=kubeadmin yarn pw:test
 ```
 
 Runs tests in the terminal without opening a browser window.
+
+#### Monitoring Tests
+
+The project includes Playwright tests for monitoring (`playwright/e2e/monitoring.spec.ts`). These tests:
+1. Enable user workload monitoring via `yarn prometheus-config enable`
+2. Verify monitoring is ready via `yarn prometheus-config verify`
+3. Verify ServiceMonitor CRD is available (scaffolding for future plugin metrics tests)
+4. Clean up by running `yarn prometheus-config disable`
+
+The tests are **skipped by default** (including in CI) to avoid requiring cluster admin permissions and additional resources.
+
+To run the monitoring infrastructure smoke test locally:
+
+```bash
+TEST_MONITORING=true KUBEADMIN_PASSWORD=kubeadmin yarn pw:test monitoring
+```
 
 #### Certificate Management Tests
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "pw:headed": "playwright test --headed",
     "lint": "yarn eslint src scripts playwright --fix && stylelint 'src/**/*.css' --allow-empty-input --fix",
     "chain-of-trust": "node scripts/chain-of-trust.js",
+    "prometheus-config": "node scripts/prometheus-config.js",
     "webpack": "node -r ts-node/register ./node_modules/.bin/webpack"
   },
   "devDependencies": {

--- a/playwright/e2e/monitoring.spec.ts
+++ b/playwright/e2e/monitoring.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { kubectl, yarn } from '../fixtures/k8s';
+
+// Minimal smoke test to verify monitoring infrastructure can be enabled.
+// This serves as scaffolding for future tests of plugin monitoring features.
+// Set TEST_MONITORING=true to run these tests, otherwise they're skipped.
+const shouldTestMonitoring = process.env.TEST_MONITORING === 'true';
+
+test.describe('User Workload Monitoring - Infrastructure Smoke Test', () => {
+  test.skip(
+    !shouldTestMonitoring,
+    'Skipping monitoring tests. Set TEST_MONITORING=true to enable.',
+  );
+
+  test('enable monitoring → verify pods → cleanup', async () => {
+    // 1. Enable user workload monitoring
+    yarn('prometheus-config enable');
+    console.log('✓ Enabled user workload monitoring');
+
+    // 2. Verify monitoring pods are ready
+    yarn('prometheus-config verify');
+    console.log('✓ Monitoring verified and ready');
+
+    // 3. Verify ServiceMonitor CRD is available (needed for plugin metrics)
+    const crd = kubectl(`get crd servicemonitors.monitoring.coreos.com`, { ignoreError: true });
+    expect(crd).toContain('servicemonitors.monitoring.coreos.com');
+    console.log('✓ ServiceMonitor CRD available');
+
+    // 4. Cleanup - disable monitoring
+    yarn('prometheus-config disable');
+    console.log('✓ Monitoring disabled');
+  });
+});

--- a/scripts/prometheus-config.js
+++ b/scripts/prometheus-config.js
@@ -1,0 +1,203 @@
+/**
+ * Prometheus User Workload Monitoring Configuration Script
+ *
+ * This script enables Prometheus user workload monitoring in OpenShift
+ * by applying the necessary ConfigMap and verifying the deployment.
+ */
+
+const { exec } = require('child_process');
+const { promisify } = require('util');
+
+const execAsync = promisify(exec);
+
+// Platform-specific configuration (override via env vars for non-OpenShift platforms)
+const MONITORING_NAMESPACE =
+  process.env.MONITORING_NAMESPACE || 'openshift-user-workload-monitoring';
+const CLUSTER_MONITORING_NAMESPACE =
+  process.env.CLUSTER_MONITORING_NAMESPACE || 'openshift-monitoring';
+const MONITORING_CONFIG = process.env.MONITORING_CONFIG || 'cluster-monitoring-config';
+
+/**
+ * Apply YAML content using kubectl
+ */
+async function applyYaml(yaml) {
+  const escapedYaml = yaml.replace(/'/g, "'\\''");
+  const { stdout, stderr } = await execAsync(`echo '${escapedYaml}' | kubectl apply -f -`);
+  if (stderr && !stderr.includes('created') && !stderr.includes('configured')) {
+    console.error('kubectl stderr:', stderr);
+  }
+  if (stdout) {
+    console.log(stdout.trim());
+  }
+}
+
+/**
+ * Get pods in a namespace
+ */
+async function getPods(namespace) {
+  try {
+    const { stdout } = await execAsync(`kubectl -n ${namespace} get pods -o json`);
+    return JSON.parse(stdout);
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Wait for pods to be ready in a namespace
+ */
+async function waitForPodsReady(timeoutMs = 300000) {
+  console.log(`⏳ Waiting for pods in ${MONITORING_NAMESPACE} to be ready...`);
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const podsData = await getPods(MONITORING_NAMESPACE);
+
+      if (podsData && podsData.items && podsData.items.length > 0) {
+        const allReady = podsData.items.every((pod) => {
+          const readyCondition = pod.status.conditions?.find((c) => c.type === 'Ready');
+          return pod.status.phase === 'Running' && readyCondition?.status === 'True';
+        });
+
+        if (allReady) {
+          console.log(`✓ All ${podsData.items.length} pod(s) in ${MONITORING_NAMESPACE} are ready`);
+          return true;
+        }
+      }
+    } catch (error) {
+      // Continue waiting
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+
+  throw new Error(`Timeout waiting for pods in ${MONITORING_NAMESPACE} to be ready`);
+}
+
+/**
+ * Wait for namespace to exist
+ */
+async function waitForNamespace(timeoutMs = 300000) {
+  console.log(`⏳ Waiting for namespace ${MONITORING_NAMESPACE} to be created...`);
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      await execAsync(`kubectl get namespace ${MONITORING_NAMESPACE}`);
+      console.log(`✓ Namespace ${MONITORING_NAMESPACE} exists`);
+      return true;
+    } catch (error) {
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+  }
+
+  throw new Error(`Timeout waiting for namespace ${MONITORING_NAMESPACE}`);
+}
+
+/**
+ * Enable user workload monitoring
+ */
+async function enableMonitoring() {
+  console.log('📝 Enabling Prometheus user workload monitoring...\n');
+
+  const configMap = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${MONITORING_CONFIG}
+  namespace: ${CLUSTER_MONITORING_NAMESPACE}
+data:
+  config.yaml: |
+    enableUserWorkload: true
+`;
+
+  await applyYaml(configMap);
+
+  console.log('\n✅ ConfigMap applied successfully');
+}
+
+/**
+ * Verify monitoring setup
+ */
+async function verifyMonitoring() {
+  console.log('\n📊 Verifying monitoring setup...\n');
+
+  // Wait for namespace
+  await waitForNamespace();
+
+  // Wait for pods to be ready
+  await waitForPodsReady();
+
+  console.log('\n✅ User workload monitoring is enabled and ready!');
+}
+
+/**
+ * Disable user workload monitoring
+ */
+async function disableMonitoring() {
+  console.log('🧹 Disabling Prometheus user workload monitoring...\n');
+
+  try {
+    await execAsync(
+      `kubectl delete configmap ${MONITORING_CONFIG} -n ${CLUSTER_MONITORING_NAMESPACE}`,
+    );
+    console.log('✅ Monitoring disabled (ConfigMap deleted)');
+  } catch (error) {
+    if (error.message.includes('NotFound')) {
+      console.log('ℹ️  ConfigMap already deleted or not found');
+    } else {
+      throw error;
+    }
+  }
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  const command = process.argv[2];
+
+  try {
+    if (!command || command === 'help' || command === '--help' || command === '-h') {
+      console.log(`
+Prometheus User Workload Monitoring Configuration
+
+Usage:
+  yarn prometheus-config <command>
+
+Commands:
+  enable    Enable user workload monitoring
+  verify    Verify monitoring setup
+  disable   Disable user workload monitoring (cleanup)
+  help      Show this help message
+
+Environment Variables (for non-OpenShift platforms):
+  MONITORING_NAMESPACE              Namespace where user workload monitoring pods run
+                                    (default: openshift-user-workload-monitoring)
+  CLUSTER_MONITORING_NAMESPACE      Namespace where cluster monitoring config is stored
+                                    (default: openshift-monitoring)
+  MONITORING_CONFIG                 Name of the ConfigMap that enables monitoring
+                                    (default: cluster-monitoring-config)
+
+Examples:
+  yarn prometheus-config enable                      # Enable on OpenShift
+  MONITORING_NAMESPACE=monitoring yarn prometheus-config enable   # Enable on custom platform
+`);
+    } else if (command === 'enable') {
+      await enableMonitoring();
+    } else if (command === 'verify') {
+      await verifyMonitoring();
+    } else if (command === 'disable') {
+      await disableMonitoring();
+    } else {
+      console.error(`Unknown command: ${command}`);
+      console.log('Run "yarn prometheus-config help" for usage information');
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('❌ Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
Introduce a script to configure the openshift cluster to monitor user workload.

Introduce a scaffolding of an E2E test for metrics. That can only be run on cluster where metrics is enabled (not the case of the CI though).

This scaffolding can be filled up with real test for metrics down the line.