### PR TITLE
[#21] Update apiVersion from arkmq.org to broker.arkmq.org in e2e tests

### DIFF
--- a/playwright/e2e/certificate-management.spec.ts
+++ b/playwright/e2e/certificate-management.spec.ts
@@ -76,7 +76,7 @@ test.describe('Certificate Management E2E', () => {
     // Step 4: Deploy BrokerService
     console.log('\n📦 Step 4: Deploying BrokerService...');
     const brokerServiceYaml = `
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerService
 metadata:
   name: ${SERVICE_NAME}
@@ -133,7 +133,7 @@ spec:
     // Step 6: Deploy BrokerApp
     console.log('\n📦 Step 6: Deploying BrokerApp...');
     const brokerAppYaml = `
-apiVersion: arkmq.org/v1beta2
+apiVersion: broker.arkmq.org/v1beta2
 kind: BrokerApp
 metadata:
   name: ${APP_NAME}


### PR DESCRIPTION
- Align BrokerService and BrokerApp apiVersion in certificate-management e2e tests with the updated operator CRD group name.

fixes: [Issue#21](https://github.com/arkmq-org/arkmq-org-broker-operator-openshift-ui/issues/21)