### PR TITLE
Configure Prometheus to scrape broker metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,9 +307,9 @@ break console styles!
 
 ## Prometheus Monitoring
 
-This project includes a script to manage Prometheus user workload monitoring in OpenShift and other Kubernetes platforms.
+This project includes scripts to manage Prometheus user workload monitoring and secure metrics scraping with mTLS authentication.
 
-### Commands
+### Enabling User Workload Monitoring
 
 **Enable user workload monitoring:**
 
@@ -334,6 +334,46 @@ yarn prometheus-config disable
 ```
 
 Removes the `cluster-monitoring-config` ConfigMap to disable user workload monitoring.
+
+### Secure Metrics Scraping with mTLS
+
+For locked-down brokers that require mutual TLS authentication, you can set up secure metrics scraping:
+
+**1. Create Prometheus Certificate:**
+
+First, create a Prometheus client certificate using the PKI infrastructure:
+
+```bash
+yarn chain-of-trust create-prometheus-cert --namespace my-namespace
+```
+
+This creates a `prometheus-cert` secret with CN=prometheus that Prometheus will use to authenticate to the broker's metrics endpoint.
+
+**2. Generate ServiceMonitor YAML:**
+
+Generate the ServiceMonitor configuration for mTLS metrics scraping:
+
+```bash
+yarn prometheus-config create-servicemonitor \
+  --broker-name my-broker \
+  --namespace my-namespace
+```
+
+**3. Apply the ServiceMonitor:**
+
+Save the output to a file or pipe directly to kubectl:
+
+```bash
+yarn prometheus-config create-servicemonitor \
+  --broker-name my-broker \
+  --namespace my-namespace | kubectl apply -f -
+```
+
+The ServiceMonitor will configure Prometheus to:
+- Scrape metrics over HTTPS
+- Authenticate using the Prometheus client certificate
+- Validate the broker's server certificate using the CA bundle
+- Target the broker's metrics endpoint (port 8888)
 
 ### Configuration for Non-OpenShift Platforms
 

--- a/bridge-auth-http/setup.sh
+++ b/bridge-auth-http/setup.sh
@@ -1,7 +1,24 @@
 #!/bin/bash
+set -euo pipefail
+
 oc process -f console-oauth-client.yaml | oc apply -f -
 oc get oauthclient console-oauth-client-http -o jsonpath='{.secret}' > console-client-secret
 oc apply -f sa-secrets.yaml
+
+# Wait for the token controller to populate the secret with ca.crt
+echo "Waiting for service account token secret to be populated..."
+for i in {1..30}; do
+    if oc get secret default-token -n default -o jsonpath='{.data.ca\.crt}' 2>/dev/null | grep -q '^[A-Za-z0-9+/=]\+$'; then
+        echo "Secret populated after ${i} seconds"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo "ERROR: Secret not populated after 30 seconds"
+        exit 1
+    fi
+    sleep 1
+done
+
 oc get secrets -n default --field-selector type=kubernetes.io/service-account-token -o json | \
     jq '.items[0].data."ca.crt"' -r | python -m base64 -d > ca.crt
 oc extract cm/kube-apiserver-server-ca -n openshift-kube-apiserver --confirm

--- a/playwright/e2e/monitoring.spec.ts
+++ b/playwright/e2e/monitoring.spec.ts
@@ -1,33 +1,365 @@
 import { test, expect } from '@playwright/test';
-import { kubectl, yarn } from '../fixtures/k8s';
+import {
+  kubectl,
+  yarn,
+  applyYaml,
+  createNamespace,
+  deleteNamespace,
+  waitForCondition,
+  waitForPod,
+  secretExists,
+} from '../fixtures/k8s';
 
-// Minimal smoke test to verify monitoring infrastructure can be enabled.
-// This serves as scaffolding for future tests of plugin monitoring features.
+// Prometheus API response types
+interface PrometheusTarget {
+  labels?: { job?: string; namespace?: string };
+  health?: string;
+  scrapeUrl?: string;
+  lastError?: string;
+}
+
+interface PrometheusTargetsResponse {
+  status: string;
+  data?: {
+    activeTargets: PrometheusTarget[];
+  };
+  error?: string;
+}
+
+interface PrometheusQueryResponse {
+  status: string;
+  data?: {
+    result: Array<{
+      metric: Record<string, string>;
+      value: [number, string];
+    }>;
+  };
+  error?: string;
+}
+
+/**
+ * Query Prometheus API by exec'ing into the Prometheus pod
+ */
+function queryPrometheusViaPod(promNs: string, query: string): PrometheusQueryResponse {
+  const encodedQuery = encodeURIComponent(query);
+  const promUrl = `http://localhost:9090/api/v1/query?query=${encodedQuery}`;
+
+  const result = kubectl(
+    `exec -n ${promNs} prometheus-user-workload-0 -c prometheus -- curl -s '${promUrl}' --max-time 10`,
+    { timeout: 30000, ignoreError: true },
+  );
+
+  if (!result) {
+    return { status: 'error', error: 'No response from Prometheus' };
+  }
+
+  try {
+    return JSON.parse(result) as PrometheusQueryResponse;
+  } catch {
+    return { status: 'error', error: 'Invalid JSON response' };
+  }
+}
+
+/**
+ * Get Prometheus targets by exec'ing into the Prometheus pod
+ */
+function getPrometheusTargetsViaPod(promNs: string): PrometheusTargetsResponse {
+  const promUrl = `http://localhost:9090/api/v1/targets`;
+
+  const result = kubectl(
+    `exec -n ${promNs} prometheus-user-workload-0 -c prometheus -- curl -s '${promUrl}' --max-time 10`,
+    { timeout: 30000, ignoreError: true },
+  );
+
+  if (!result) {
+    return { status: 'error', error: 'No response from Prometheus' };
+  }
+
+  try {
+    return JSON.parse(result) as PrometheusTargetsResponse;
+  } catch {
+    return { status: 'error', error: 'Invalid JSON response' };
+  }
+}
+
+// E2E test to verify monitoring infrastructure and ServiceMonitor setup for metrics scraping.
 // Set TEST_MONITORING=true to run these tests, otherwise they're skipped.
 const shouldTestMonitoring = process.env.TEST_MONITORING === 'true';
+const TEST_NAMESPACE = 'monitoring-test';
 
-test.describe('User Workload Monitoring - Infrastructure Smoke Test', () => {
+test.describe('Prometheus Monitoring - ServiceMonitor Setup', () => {
   test.skip(
     !shouldTestMonitoring,
     'Skipping monitoring tests. Set TEST_MONITORING=true to enable.',
   );
 
-  test('enable monitoring → verify pods → cleanup', async () => {
-    // 1. Enable user workload monitoring
-    yarn('prometheus-config enable');
-    console.log('✓ Enabled user workload monitoring');
-
-    // 2. Verify monitoring pods are ready
-    yarn('prometheus-config verify');
-    console.log('✓ Monitoring verified and ready');
-
-    // 3. Verify ServiceMonitor CRD is available (needed for plugin metrics)
-    const crd = kubectl(`get crd servicemonitors.monitoring.coreos.com`, { ignoreError: true });
-    expect(crd).toContain('servicemonitors.monitoring.coreos.com');
-    console.log('✓ ServiceMonitor CRD available');
-
-    // 4. Cleanup - disable monitoring
+  test.afterAll(async () => {
+    // Cleanup test namespace and infrastructure
+    console.log('\n🧹 Cleaning up...');
+    deleteNamespace(TEST_NAMESPACE);
+    yarn('chain-of-trust cleanup');
     yarn('prometheus-config disable');
-    console.log('✓ Monitoring disabled');
+    console.log('✓ Cleanup complete');
+
+    console.log('\n✅ E2E Tests Complete\n');
+  });
+
+  test('complete monitoring setup with ServiceMonitor', async () => {
+    console.log('\n📊 Testing complete Prometheus monitoring setup\n');
+
+    // Enable user workload monitoring
+    console.log('Step 1: Enabling user workload monitoring...');
+    yarn('prometheus-config enable');
+    console.log('✓ User workload monitoring enabled');
+
+    // Verify monitoring pods are ready
+    console.log('\nStep 2: Verifying monitoring infrastructure...');
+    yarn('prometheus-config verify', { timeout: 360000 });
+    console.log('✓ Monitoring infrastructure ready');
+
+    // Setup PKI infrastructure
+    console.log('\nStep 3: Setting up PKI infrastructure...');
+    yarn('chain-of-trust setup');
+    console.log('✓ PKI infrastructure created');
+
+    // Create test namespace
+    console.log('\nStep 4: Creating test namespace...');
+    createNamespace(TEST_NAMESPACE);
+    console.log(`✓ Namespace ${TEST_NAMESPACE} created`);
+    //
+    // Create broker certificate for the test broker
+    console.log('\nStep 5: Creating broker certificate...');
+    yarn(`chain-of-trust create-service-cert --name test-broker --namespace ${TEST_NAMESPACE}`);
+
+    // Verify broker certificate was created
+    expect(secretExists('test-broker-broker-cert', TEST_NAMESPACE)).toBe(true);
+    console.log('✓ Broker certificate created');
+
+    // Deploy a real BrokerService to test metrics scraping
+    console.log('\nStep 6: Deploying real BrokerService with metrics enabled...');
+    const brokerServiceYaml = `
+apiVersion: broker.arkmq.org/v1beta2
+kind: BrokerService
+metadata:
+  name: test-broker
+  namespace: ${TEST_NAMESPACE}
+  labels:
+    forWorkQueue: "true"
+spec:
+  resources:
+    limits:
+      memory: "256Mi"
+  env:
+    - name: JAVA_ARGS_APPEND
+      value: "-Dlog4j2.level=INFO"
+`;
+    applyYaml(brokerServiceYaml);
+
+    // Wait for BrokerService to be deployed
+    console.log('⏳ Waiting for BrokerService to be deployed...');
+    await waitForCondition(
+      'brokerservice',
+      'test-broker',
+      TEST_NAMESPACE,
+      'Deployed',
+      'True',
+      600000,
+    );
+    console.log('✓ BrokerService deployed');
+
+    // Wait for broker pod to be ready
+    console.log('⏳ Waiting for broker pod to be ready...');
+    await waitForPod(`test-broker-ss-0`, TEST_NAMESPACE, 600000);
+    console.log('✓ Broker pod is ready');
+
+    // Deploy BrokerApp to create queues (ensures metrics are exported)
+    console.log('\nStep 6a: Creating BrokerApp certificate...');
+    yarn(`chain-of-trust create-app-cert --name test-app --namespace ${TEST_NAMESPACE}`);
+    expect(secretExists('test-app-app-cert', TEST_NAMESPACE)).toBe(true);
+    console.log('✓ BrokerApp certificate created');
+
+    console.log('\nStep 6b: Deploying BrokerApp to create queues...');
+    const brokerAppYaml = `
+apiVersion: broker.arkmq.org/v1beta2
+kind: BrokerApp
+metadata:
+  name: test-app
+  namespace: ${TEST_NAMESPACE}
+spec:
+  selector:
+    matchLabels:
+      forWorkQueue: "true"
+  acceptor:
+    port: 61616
+  capabilities:
+  - consumerOf:
+    - address: "APP.JOBS"
+  - producerOf:
+    - address: "APP.JOBS"
+`;
+    applyYaml(brokerAppYaml);
+
+    console.log('\nStep 6c: Waiting for BrokerApp to be provisioned...');
+    await waitForCondition('brokerapp', 'test-app', TEST_NAMESPACE, 'Deployed', 'True', 300000);
+    console.log('✓ BrokerApp deployed - queues created and metrics exported');
+
+    // Create Prometheus certificate
+    console.log('\nStep 7: Creating Prometheus certificate...');
+    yarn(`chain-of-trust create-prometheus-cert --namespace ${TEST_NAMESPACE}`);
+
+    // Wait for cert-manager to provision the certificate
+    console.log('⏳ Waiting for Prometheus certificate to be ready...');
+    kubectl(
+      `wait --for=condition=Ready certificate/prometheus-cert -n ${TEST_NAMESPACE} --timeout=60s`,
+    );
+    console.log('✓ Prometheus certificate ready');
+
+    // Setup complete monitoring stack (Service + ServiceMonitor + namespace label)
+    console.log('\nStep 8: Setting up monitoring stack...');
+    yarn(
+      `prometheus-config setup-monitoring --broker-name test-broker --namespace ${TEST_NAMESPACE}`,
+    );
+
+    // Verify resources were created
+    const serviceMonitor = kubectl(`get servicemonitor test-broker-monitor -n ${TEST_NAMESPACE}`);
+    expect(serviceMonitor).toContain('test-broker-monitor');
+    const metricsService = kubectl(`get service test-broker-metrics -n ${TEST_NAMESPACE}`);
+    expect(metricsService).toContain('test-broker-metrics');
+    console.log('✓ Monitoring stack created (Service + ServiceMonitor)');
+
+    // Wait a bit for Prometheus to reload config and discover the ServiceMonitor
+    console.log('⏳ Waiting for Prometheus to reload configuration...');
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+    console.log('✓ Configuration reload complete');
+
+    // 9. Verify Prometheus actually scrapes metrics
+    console.log('\nStep 9: Verifying Prometheus scrapes metrics from the broker...');
+
+    const promNs = 'openshift-user-workload-monitoring';
+    const promService = 'prometheus-operated';
+
+    // Verify Prometheus service exists
+    const promSvc = kubectl(`get service ${promService} -n ${promNs} -o name`, {
+      ignoreError: true,
+    });
+    expect(promSvc).toBeTruthy();
+    expect(promSvc.length).toBeGreaterThan(0);
+    console.log(`✓ Prometheus service found: ${promService}`);
+
+    console.log('⏳ Querying Prometheus via ephemeral curl pod...');
+
+    // Wait for ServiceMonitor to be discovered by Prometheus (can take up to 90s for certs to propagate + mTLS handshake)
+    console.log('⏳ Waiting for Prometheus to discover ServiceMonitor target...');
+    let targetFound = false;
+    let targetUp = false;
+    const maxAttempts = 45; // 45 attempts * 2s = 90s max wait
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const targetsResponse = getPrometheusTargetsViaPod(promNs);
+
+      if (targetsResponse.status === 'success' && targetsResponse.data) {
+        const activeTargets = targetsResponse.data.activeTargets;
+
+        // Debug: show all targets on first attempt
+        if (attempt === 1) {
+          console.log(`  Found ${activeTargets.length} active targets in Prometheus`);
+          activeTargets.forEach((t) => {
+            console.log(`    - job=${t.labels?.job}, namespace=${t.labels?.namespace}`);
+          });
+        }
+
+        // Find our ServiceMonitor target - try multiple patterns
+        const target = activeTargets.find(
+          (t) =>
+            t.labels?.namespace === TEST_NAMESPACE ||
+            t.labels?.job?.includes('test-broker') ||
+            t.scrapeUrl?.includes(TEST_NAMESPACE),
+        );
+
+        if (target) {
+          targetFound = true;
+          const health = target.health;
+          const lastError = target.lastError || 'no error message';
+          console.log(
+            `  Attempt ${attempt}: Target found, job=${target.labels?.job}, health=${health}`,
+          );
+
+          if (health === 'down') {
+            console.log(`  Last error: ${lastError}`);
+          }
+
+          if (health === 'up') {
+            targetUp = true;
+            console.log(`✓ Target is UP and being scraped`);
+            break;
+          }
+        } else {
+          console.log(`  Attempt ${attempt}: Target not yet discovered`);
+        }
+      }
+
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+    }
+
+    expect(targetFound).toBe(true);
+    expect(targetUp).toBe(true);
+
+    // List all available metrics
+    console.log('\n⏳ Listing all available broker metrics...');
+    const allMetricsQuery = `{namespace="${TEST_NAMESPACE}"}`;
+    const allMetricsResponse = queryPrometheusViaPod(promNs, allMetricsQuery);
+
+    expect(allMetricsResponse.status).toBe('success');
+    expect(allMetricsResponse.data).toBeDefined();
+
+    if (!allMetricsResponse.data) {
+      throw new Error('Prometheus returned no data');
+    }
+
+    const metricNames = new Set<string>();
+    const pods = new Set<string>();
+    const jobs = new Set<string>();
+    allMetricsResponse.data.result.forEach((r) => {
+      if (r.metric.__name__) metricNames.add(r.metric.__name__);
+      if (r.metric.pod) pods.add(r.metric.pod);
+      if (r.metric.job) jobs.add(r.metric.job);
+    });
+    console.log(
+      `✓ Found ${metricNames.size} unique metric types from ${pods.size} pod(s), ${jobs.size} job(s)`,
+    );
+    console.log(`✓ Pods: ${Array.from(pods).join(', ')}`);
+    console.log(`✓ Jobs: ${Array.from(jobs).join(', ')}`);
+    console.log(`\n✓ Metric types:`);
+    Array.from(metricNames)
+      .sort()
+      .forEach((name) => console.log(`    - ${name}`));
+
+    // Query for actual broker queue metrics (proves real metrics are being scraped)
+    console.log('\n⏳ Querying for broker queue metrics...');
+    // Query for the APP.JOBS queue created by BrokerApp
+    const queueMetricsQuery = `broker_queue_message_count{namespace="${TEST_NAMESPACE}",queue="APP.JOBS"}`;
+    const queueMetricsResponse = queryPrometheusViaPod(promNs, queueMetricsQuery);
+
+    expect(queueMetricsResponse.status).toBe('success');
+    expect(queueMetricsResponse.data).toBeDefined();
+
+    if (!queueMetricsResponse.data) {
+      throw new Error('Prometheus returned no data');
+    }
+
+    expect(queueMetricsResponse.data.result.length).toBeGreaterThan(0);
+
+    const queueMetric = queueMetricsResponse.data.result[0];
+    console.log(
+      `✓ Queue metrics found: queue=${queueMetric.metric.queue}, address=${queueMetric.metric.address}`,
+    );
+    console.log(`✓ broker_queue_message_count value: ${queueMetric.value[1]}`);
+
+    // Verify the metric value is valid (should be 0 or more)
+    expect(parseFloat(queueMetric.value[1])).toBeGreaterThanOrEqual(0);
+
+    console.log('\n✅ Prometheus is successfully scraping broker queue metrics with mTLS!');
   });
 });

--- a/playwright/fixtures/k8s.ts
+++ b/playwright/fixtures/k8s.ts
@@ -1,4 +1,12 @@
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
+
+/**
+ * Strip ANSI color codes and control characters from a string
+ */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '').replace(/\x1B\][^\x07]*\x07/g, '');
+}
 
 /**
  * Execute a kubectl command
@@ -32,7 +40,16 @@ export function yarn(args: string, options: { timeout?: number } = {}): string {
     timeout: options.timeout || 120000,
     stdio: ['pipe', 'pipe', 'pipe'],
   });
-  return result.trim();
+  // Strip ANSI color codes and control characters
+  let cleaned = stripAnsi(result.trim());
+
+  // Yarn outputs "$ command" on the first line, skip it
+  const lines = cleaned.split('\n');
+  if (lines.length > 0 && lines[0].startsWith('$')) {
+    cleaned = lines.slice(1).join('\n');
+  }
+
+  return cleaned.trim();
 }
 
 export async function sleep(ms: number): Promise<void> {
@@ -224,4 +241,57 @@ export async function waitForJob(
   }
 
   throw new Error(`Timeout waiting for job ${jobName} in namespace ${namespace}`);
+}
+
+/**
+ * Port-forward to a pod and return cleanup function
+ */
+export function startPortForward(
+  podName: string,
+  namespace: string,
+  localPort: number,
+  remotePort: number,
+): { cleanup: () => void; baseUrl: string } {
+  const proc = spawn('kubectl', [
+    'port-forward',
+    '-n',
+    namespace,
+    podName,
+    `${localPort}:${remotePort}`,
+  ]);
+
+  // Give port-forward time to establish
+  execSync('sleep 2');
+
+  const cleanup = () => {
+    proc.kill();
+  };
+
+  return {
+    cleanup,
+    baseUrl: `http://localhost:${localPort}`,
+  };
+}
+
+/**
+ * Query Prometheus API
+ */
+export function queryPrometheus(baseUrl: string, query: string): Record<string, unknown> {
+  const encodedQuery = encodeURIComponent(query);
+  const result = execSync(`curl -s "${baseUrl}/api/v1/query?query=${encodedQuery}"`, {
+    encoding: 'utf-8',
+    timeout: 30000,
+  });
+  return JSON.parse(result.trim()) as Record<string, unknown>;
+}
+
+/**
+ * Get Prometheus targets
+ */
+export function getPrometheusTargets(baseUrl: string): Record<string, unknown> {
+  const result = execSync(`curl -s "${baseUrl}/api/v1/targets"`, {
+    encoding: 'utf-8',
+    timeout: 30000,
+  });
+  return JSON.parse(result.trim()) as Record<string, unknown>;
 }

--- a/scripts/chain-of-trust.js
+++ b/scripts/chain-of-trust.js
@@ -9,12 +9,14 @@
  *   yarn chain-of-trust setup [options]
  *   yarn chain-of-trust create-service-cert --name <service-name> --namespace <namespace>
  *   yarn chain-of-trust create-app-cert --name <app-name> --namespace <namespace>
+ *   yarn chain-of-trust create-prometheus-cert --namespace <namespace>
  *   yarn chain-of-trust cleanup [options]
  *
  * Commands:
  *   setup                       Create PKI infrastructure (root CA, issuers, trust bundle, operator cert)
  *   create-service-cert         Create certificate for a BrokerService
  *   create-app-cert             Create certificate for a BrokerApp
+ *   create-prometheus-cert      Create certificate for Prometheus metrics scraping with mTLS
  *   cleanup                     Remove PKI infrastructure
  *
  * Options:
@@ -23,7 +25,12 @@
  *   --help                      Show this help message
  */
 
-const { setupCompletePKI, createServiceCertificate, createAppCertificate } = require('./setup-pki');
+const {
+  setupCompletePKI,
+  createServiceCertificate,
+  createAppCertificate,
+  createPrometheusCertificate,
+} = require('./setup-pki');
 const { exec } = require('child_process');
 const { promisify } = require('util');
 
@@ -46,16 +53,18 @@ Usage:
   yarn chain-of-trust setup
   yarn chain-of-trust create-service-cert --name <service-name> --namespace <namespace>
   yarn chain-of-trust create-app-cert --name <app-name> --namespace <namespace>
+  yarn chain-of-trust create-prometheus-cert --namespace <namespace>
   yarn chain-of-trust cleanup
 
 Commands:
   setup                       Create PKI infrastructure (root CA, issuers, trust bundle, operator cert)
   create-service-cert         Create certificate for a BrokerService
   create-app-cert             Create certificate for a BrokerApp
+  create-prometheus-cert      Create certificate for Prometheus metrics scraping with mTLS
   cleanup                     Remove PKI infrastructure
 
 Options:
-  --namespace <name>          Target namespace (required for create-service-cert and create-app-cert)
+  --namespace <name>          Target namespace (required for create-service-cert, create-app-cert, create-prometheus-cert)
   --name <name>               Resource name (required for create-service-cert and create-app-cert)
   --help                      Show this help message
 
@@ -68,6 +77,9 @@ Examples:
 
   # Create a certificate for a BrokerApp
   yarn chain-of-trust create-app-cert --name first-app --namespace app-namespace
+
+  # Create certificate for Prometheus to scrape broker metrics with mTLS
+  yarn chain-of-trust create-prometheus-cert --namespace my-namespace
 
   # Cleanup all PKI resources
   yarn chain-of-trust cleanup
@@ -91,7 +103,13 @@ for (let i = 1; i < args.length; i++) {
   }
 }
 
-const validCommands = ['setup', 'create-service-cert', 'create-app-cert', 'cleanup'];
+const validCommands = [
+  'setup',
+  'create-service-cert',
+  'create-app-cert',
+  'create-prometheus-cert',
+  'cleanup',
+];
 if (!command || !validCommands.includes(command)) {
   console.error(`Error: Please specify a valid command (${validCommands.join(', ')})`);
   showHelp();
@@ -240,6 +258,42 @@ async function createAppCert() {
 }
 
 /**
+ * Create Prometheus Certificate function
+ */
+async function createPrometheusCert() {
+  if (!namespace) {
+    console.error('\n❌ Error: --namespace is required for create-prometheus-cert');
+    showHelp();
+  }
+
+  console.log(
+    `\n📜 Creating certificate for Prometheus metrics scraping in namespace ${namespace}\n`,
+  );
+
+  try {
+    const result = await createPrometheusCertificate(namespace, resourceNames.caIssuer);
+
+    console.log('\n✅ Prometheus Certificate Created!\n');
+    console.log(`Created resources:`);
+    console.log(`  ✓ Certificate: ${result.certName}`);
+    console.log(`  ✓ Secret: ${result.secretName}`);
+    console.log(
+      `\nYou can now configure Prometheus to scrape broker metrics with mTLS in namespace ${namespace}`,
+    );
+    console.log(
+      `Use "yarn prometheus-config create-servicemonitor" to generate ServiceMonitor YAML\n`,
+    );
+  } catch (error) {
+    console.error('\n❌ Error creating Prometheus certificate:', error.message);
+    console.error('\nMake sure:');
+    console.error('  - PKI infrastructure is set up (run "yarn chain-of-trust setup" first)');
+    console.error('  - The namespace exists');
+    console.error('  - kubectl is configured correctly\n');
+    process.exit(1);
+  }
+}
+
+/**
  * Cleanup function - removes PKI infrastructure
  */
 async function cleanup() {
@@ -272,6 +326,11 @@ async function cleanup() {
     await deleteCertificatePattern('app-cert');
     await deleteSecretPattern('app-cert');
 
+    // Delete all Prometheus certificates
+    console.log('  Deleting all Prometheus certificates...');
+    await deleteCertificatePattern('prometheus-cert');
+    await deleteSecretPattern('prometheus-cert');
+
     // Delete ClusterIssuers
     console.log('  Deleting ClusterIssuers...');
     await execAsync(
@@ -295,6 +354,7 @@ async function cleanup() {
     );
     console.log(`  ✓ All BrokerService certificates and secrets (pattern: *broker-cert*)`);
     console.log(`  ✓ All BrokerApp certificates and secrets (pattern: *app-cert*)`);
+    console.log(`  ✓ All Prometheus certificates and secrets (pattern: *prometheus-cert*)`);
     console.log(`  ✓ ClusterIssuers: ${resourceNames.rootIssuer}, ${resourceNames.caIssuer}`);
     console.log(`  ✓ Certificate: ${resourceNames.rootCert} (from cert-manager)`);
     console.log(`  ✓ Secret: ${resourceNames.rootSecret} (from cert-manager)\n`);
@@ -312,6 +372,8 @@ if (command === 'setup') {
   createServiceCert();
 } else if (command === 'create-app-cert') {
   createAppCert();
+} else if (command === 'create-prometheus-cert') {
+  createPrometheusCert();
 } else if (command === 'cleanup') {
   cleanup();
 }

--- a/scripts/prometheus-config.js
+++ b/scripts/prometheus-config.js
@@ -49,20 +49,35 @@ async function getPods(namespace) {
 async function waitForPodsReady(timeoutMs = 300000) {
   console.log(`⏳ Waiting for pods in ${MONITORING_NAMESPACE} to be ready...`);
   const startTime = Date.now();
+  let podsCreated = false;
 
   while (Date.now() - startTime < timeoutMs) {
     try {
       const podsData = await getPods(MONITORING_NAMESPACE);
 
       if (podsData && podsData.items && podsData.items.length > 0) {
-        const allReady = podsData.items.every((pod) => {
-          const readyCondition = pod.status.conditions?.find((c) => c.type === 'Ready');
-          return pod.status.phase === 'Running' && readyCondition?.status === 'True';
-        });
+        // Filter out error/completed pods from kubectl run (prom-targets-*, prom-query-*)
+        const relevantPods = podsData.items.filter(
+          (pod) =>
+            !pod.metadata.name.startsWith('prom-targets-') &&
+            !pod.metadata.name.startsWith('prom-query-'),
+        );
 
-        if (allReady) {
-          console.log(`✓ All ${podsData.items.length} pod(s) in ${MONITORING_NAMESPACE} are ready`);
-          return true;
+        if (relevantPods.length > 0) {
+          if (!podsCreated) {
+            console.log(`  Found ${relevantPods.length} monitoring pod(s), waiting for ready...`);
+            podsCreated = true;
+          }
+
+          const allReady = relevantPods.every((pod) => {
+            const readyCondition = pod.status.conditions?.find((c) => c.type === 'Ready');
+            return pod.status.phase === 'Running' && readyCondition?.status === 'True';
+          });
+
+          if (allReady) {
+            console.log(`✓ All ${relevantPods.length} pod(s) in ${MONITORING_NAMESPACE} are ready`);
+            return true;
+          }
         }
       }
     } catch (error) {
@@ -152,10 +167,136 @@ async function disableMonitoring() {
 }
 
 /**
+ * Generate metrics Service YAML for Prometheus scraping
+ */
+function generateMetricsService(options = {}) {
+  const { brokerName = 'artemis-broker', namespace = 'default', metricsPort = 8888 } = options;
+
+  return `---
+# Metrics Service for Prometheus scraping
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${brokerName}-metrics
+  namespace: ${namespace}
+  labels:
+    app: ${brokerName}
+spec:
+  selector:
+    ActiveMQArtemis: ${brokerName}
+  ports:
+  - name: metrics
+    port: ${metricsPort}
+    targetPort: ${metricsPort}
+    protocol: TCP
+  type: ClusterIP
+`;
+}
+
+/**
+ * Generate ServiceMonitor YAML for scraping broker metrics with mTLS
+ */
+function generateServiceMonitor(options = {}) {
+  const {
+    brokerName = 'artemis-broker',
+    namespace = 'default',
+    brokerFqdn = `${options.brokerName || 'artemis-broker'}-ss-0.${
+      options.brokerName || 'artemis-broker'
+    }-hdls-svc.${namespace}.svc.cluster.local`,
+    prometheusCertSecret = 'prometheus-cert',
+    caSecret = 'activemq-artemis-manager-ca',
+  } = options;
+
+  return `---
+# ServiceMonitor for scraping locked-down broker metrics with mTLS
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ${brokerName}-monitor
+  namespace: ${namespace}
+  labels:
+    app: ${brokerName}
+spec:
+  selector:
+    matchLabels:
+      app: ${brokerName}
+  endpoints:
+  - port: metrics
+    scheme: https
+    path: /metrics
+    tlsConfig:
+      serverName: '${brokerFqdn}'
+      ca:
+        secret:
+          name: ${caSecret}
+          key: ca.pem
+      cert:
+        secret:
+          name: ${prometheusCertSecret}
+          key: tls.crt
+      keySecret:
+        name: ${prometheusCertSecret}
+        key: tls.key
+`;
+}
+
+/**
+ * Setup complete monitoring stack (Service + ServiceMonitor + namespace label)
+ */
+async function setupMonitoring(options = {}) {
+  const { brokerName = 'artemis-broker', namespace = 'default' } = options;
+
+  console.log('📊 Setting up Prometheus monitoring...\n');
+
+  // Label namespace for user monitoring
+  console.log('📝 Labeling namespace for user monitoring...');
+  try {
+    await execAsync(
+      `kubectl label namespace ${namespace} openshift.io/user-monitoring=true --overwrite`,
+    );
+    console.log('✓ Namespace labeled');
+  } catch (error) {
+    console.error('❌ Failed to label namespace:', error.message);
+    throw error;
+  }
+
+  // Create metrics Service
+  console.log('\n📝 Creating metrics Service...');
+  const serviceYaml = generateMetricsService(options);
+  await applyYaml(serviceYaml);
+  console.log('✓ Metrics Service created');
+
+  // Create ServiceMonitor
+  console.log('\n📝 Creating ServiceMonitor...');
+  const serviceMonitorYaml = generateServiceMonitor(options);
+  await applyYaml(serviceMonitorYaml);
+  console.log('✓ ServiceMonitor created');
+
+  console.log('\n✅ Monitoring setup complete!');
+  console.log(`\nPrometheus will scrape metrics from ${brokerName} via mTLS.`);
+}
+
+/**
  * Main function
  */
 async function main() {
   const command = process.argv[2];
+
+  // Parse command-line options
+  const args = process.argv.slice(3);
+  const options = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--broker-name' && args[i + 1]) {
+      options.brokerName = args[i + 1];
+      i++;
+    } else if (args[i] === '--namespace' && args[i + 1]) {
+      options.namespace = args[i + 1];
+      i++;
+    } else if (args[i] === '--broker-fqdn' && args[i + 1]) {
+      options.brokerFqdn = args[i + 1];
+      i++;
+    }
+  }
 
   try {
     if (!command || command === 'help' || command === '--help' || command === '-h') {
@@ -163,13 +304,19 @@ async function main() {
 Prometheus User Workload Monitoring Configuration
 
 Usage:
-  yarn prometheus-config <command>
+  yarn prometheus-config <command> [options]
 
 Commands:
-  enable    Enable user workload monitoring
-  verify    Verify monitoring setup
-  disable   Disable user workload monitoring (cleanup)
-  help      Show this help message
+  enable              Enable user workload monitoring
+  verify              Verify monitoring setup
+  disable             Disable user workload monitoring (cleanup)
+  setup-monitoring    Setup complete monitoring stack (Service + ServiceMonitor + namespace label)
+  help                Show this help message
+
+Options for setup-monitoring:
+  --broker-name <name>    Broker name (default: artemis-broker)
+  --namespace <ns>        Target namespace (default: default)
+  --broker-fqdn <fqdn>    Broker FQDN for TLS validation (auto-generated if omitted)
 
 Environment Variables (for non-OpenShift platforms):
   MONITORING_NAMESPACE              Namespace where user workload monitoring pods run
@@ -180,8 +327,17 @@ Environment Variables (for non-OpenShift platforms):
                                     (default: cluster-monitoring-config)
 
 Examples:
-  yarn prometheus-config enable                      # Enable on OpenShift
-  MONITORING_NAMESPACE=monitoring yarn prometheus-config enable   # Enable on custom platform
+  # Enable user workload monitoring on OpenShift
+  yarn prometheus-config enable
+
+  # Enable on custom platform
+  MONITORING_NAMESPACE=monitoring yarn prometheus-config enable
+
+  # Setup monitoring for a broker
+  yarn prometheus-config setup-monitoring --broker-name my-broker --namespace my-namespace
+
+  # Verify monitoring is working
+  yarn prometheus-config verify
 `);
     } else if (command === 'enable') {
       await enableMonitoring();
@@ -189,6 +345,8 @@ Examples:
       await verifyMonitoring();
     } else if (command === 'disable') {
       await disableMonitoring();
+    } else if (command === 'setup-monitoring') {
+      await setupMonitoring(options);
     } else {
       console.error(`Unknown command: ${command}`);
       console.log('Run "yarn prometheus-config help" for usage information');

--- a/scripts/setup-pki.js
+++ b/scripts/setup-pki.js
@@ -354,6 +354,49 @@ spec:
 }
 
 /**
+ * Creates a certificate for Prometheus to scrape broker metrics with mTLS
+ *
+ * @param {string} namespace - Namespace where the Prometheus certificate should be created
+ * @param {string} caIssuerName - Name of the CA issuer to use for signing
+ * @returns {Promise<object>} Resource names that were created
+ */
+async function createPrometheusCertificate(namespace, caIssuerName) {
+  console.log(
+    `📦 Creating certificate for Prometheus metrics scraping in namespace ${namespace}...`,
+  );
+
+  // Wait for the CA secret to appear in the namespace (distributed by trust-manager)
+  const bundleName = 'activemq-artemis-manager-ca';
+  console.log(`⏳ Waiting for CA secret to be distributed to namespace ${namespace}...`);
+  await waitForSecret(namespace, bundleName);
+
+  const certName = 'prometheus-cert';
+
+  const certYaml = `
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${certName}
+  namespace: ${namespace}
+spec:
+  secretName: ${certName}
+  commonName: prometheus
+  issuerRef:
+    name: ${caIssuerName}
+    kind: ClusterIssuer
+`;
+  await applyYaml(certYaml);
+  await waitForCertificate(namespace, certName);
+
+  console.log(`✅ Certificate ${certName} created successfully for Prometheus`);
+
+  return {
+    certName: certName,
+    secretName: certName,
+  };
+}
+
+/**
  * Creates the complete PKI infrastructure (cluster infra + trust bundle + operator cert)
  * Note: The operator cert is always created in the 'default' namespace where the operator
  * is hardcoded to look for it (see DefaultOperatorCertSecretName in operator code)
@@ -414,6 +457,7 @@ module.exports = {
   createOperatorCert,
   createServiceCertificate,
   createAppCertificate,
+  createPrometheusCertificate,
   setupCompletePKI,
   detectOperatorNamespace,
   execAsync,


### PR DESCRIPTION
Configure Prometheus to scrape broker metrics.

In the namespace test after creating a broker service:

```
yarn prometheus-config enable
yarn prometheus-config verify
yarn chain-of-trust create-prometheus-cert --namespace test
yarn prometheus-config create-servicemonitor --broker-name test-broker --namespace test
```

See `playwright/e2e/monitoring.spec.ts` and `README` for more details
The test can only be executed on a cluster with enabled monitoring:

```
crc config view
- enable-cluster-monitoring             : true
```

To run the suite with monitoring:
`TEST_MONITORING=true KUBEADMIN_PASSWORD=kubeadmin yarn pw:test`