### PR TITLE
[NO-ISSUE] fix: remove spec.acceptor from BrokerApp test YAML

### DIFF
--- a/playwright/e2e/certificate-management.spec.ts
+++ b/playwright/e2e/certificate-management.spec.ts
@@ -142,8 +142,6 @@ spec:
   selector:
     matchLabels:
       forWorkQueue: "true"
-  acceptor:
-    port: 61616
   capabilities:
   - producerOf:
     - address: "APP.JOBS"

--- a/playwright/e2e/monitoring.spec.ts
+++ b/playwright/e2e/monitoring.spec.ts
@@ -189,8 +189,6 @@ spec:
   selector:
     matchLabels:
       forWorkQueue: "true"
-  acceptor:
-    port: 61616
   capabilities:
   - consumerOf:
     - address: "APP.JOBS"


### PR DESCRIPTION
The BrokerApp CRD no longer supports spec.acceptor - the port is auto-assigned by the operator. This was causing certificate-management and monitoring e2e tests to fail with:
"strict decoding error: unknown field spec.acceptor"