### PR TITLE
[#33] fix: certificate-management E2E CI failure on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ The `setup` command creates:
 - `ClusterIssuer/root-issuer` - Self-signed root issuer
 - `Certificate/root-cert` (in cert-manager namespace) - Root CA certificate
 - `ClusterIssuer/broker-ca-issuer` - CA issuer for signing broker certificates
-- `Bundle/activemq-artemis-manager-ca` - Trust bundle distributed to all namespaces
-- `Certificate/activemq-artemis-manager-cert` - Operator certificate
+- `Bundle/arkmq-org-broker-manager-ca` - Trust bundle distributed to all namespaces
+- `Certificate/arkmq-org-broker-manager-cert` - Operator certificate
 
 The `create-service-cert` command creates:
 - `Certificate/<service-name>-broker-cert` - Service certificate with proper DNS names

--- a/playwright/e2e/certificate-management.spec.ts
+++ b/playwright/e2e/certificate-management.spec.ts
@@ -30,14 +30,17 @@ test.describe('Certificate Management E2E', () => {
   });
 
   test('complete workflow: setup, deploy, and cleanup', async () => {
+    // Playwright default is 8 min; this workflow needs up to ~30 min on CRC CI.
+    test.setTimeout(1_800_000); // 30 minutes
+
     // Step 1: Setup PKI infrastructure
     console.log('\n📦 Step 1: Setting up PKI infrastructure...');
     const setupOutput = yarn('chain-of-trust setup', { timeout: 180000 });
     expect(setupOutput).toContain('Chain of Trust Setup Complete');
     expect(setupOutput).toContain('ClusterIssuer: root-issuer');
     expect(setupOutput).toContain('ClusterIssuer: broker-ca-issuer');
-    expect(setupOutput).toContain('Bundle: activemq-artemis-manager-ca');
-    expect(setupOutput).toContain('Certificate: activemq-artemis-manager-cert');
+    expect(setupOutput).toContain('Bundle: arkmq-org-broker-manager-ca');
+    expect(setupOutput).toContain('Certificate: arkmq-org-broker-manager-cert');
     expect(setupOutput).toContain('in default namespace');
 
     // Verify ClusterIssuers are ready
@@ -54,7 +57,7 @@ test.describe('Certificate Management E2E', () => {
     // Verify operator certificate was created in default namespace
     const operatorNamespace = 'default';
     console.log(`  ✓ Operator certificate created in default namespace`);
-    expect(secretExists('activemq-artemis-manager-cert', operatorNamespace)).toBe(true);
+    expect(secretExists('arkmq-org-broker-manager-cert', operatorNamespace)).toBe(true);
 
     // Step 2: Create test namespace
     console.log('\n📦 Step 2: Creating test namespace...');
@@ -70,7 +73,7 @@ test.describe('Certificate Management E2E', () => {
     expect(serviceCertOutput).toContain(`${SERVICE_NAME}-broker-cert`);
 
     // Verify certificates exist
-    expect(secretExists('activemq-artemis-manager-ca', TEST_NAMESPACE)).toBe(true);
+    expect(secretExists('arkmq-org-broker-manager-ca', TEST_NAMESPACE)).toBe(true);
     expect(secretExists(`${SERVICE_NAME}-broker-cert`, TEST_NAMESPACE)).toBe(true);
 
     // Step 4: Deploy BrokerService
@@ -156,7 +159,7 @@ spec:
 
     // Wait for BrokerApp to be provisioned on the broker (acceptor + JAAS config active)
     console.log('\n⏳ Waiting for BrokerApp to be provisioned on the broker...');
-    await waitForCondition('brokerapp', APP_NAME, TEST_NAMESPACE, 'Deployed', 'True', 300000);
+    await waitForCondition('brokerapp', APP_NAME, TEST_NAMESPACE, 'Deployed', 'True', 600000);
 
     // Verify binding secret was created
     console.log('\n✓ Verifying app binding secret...');
@@ -180,9 +183,9 @@ spec:
     };
     const secretNames = secretsJson.items.map((s) => s.metadata.name);
 
-    expect(secretNames).toContain('activemq-artemis-manager-ca');
+    expect(secretNames).toContain('arkmq-org-broker-manager-ca');
     // Operator cert is in default namespace (hardcoded in operator)
-    expect(secretExists('activemq-artemis-manager-cert', 'default')).toBe(true);
+    expect(secretExists('arkmq-org-broker-manager-cert', 'default')).toBe(true);
     expect(secretNames).toContain(`${SERVICE_NAME}-broker-cert`);
     expect(secretNames).toContain(`${APP_NAME}-app-cert`);
     expect(secretNames).toContain(`${APP_NAME}-binding-secret`);
@@ -195,6 +198,23 @@ spec:
     expect(bindingData).toHaveProperty('uri');
     expect(bindingData).toHaveProperty('host');
     expect(bindingData).toHaveProperty('port');
+
+    // Operator round-trip pattern: binding-secret host/port are env vars expanded by sh -c before java runs.
+    const amqpProducerCommand =
+      'exec java -classpath /opt/amq/lib/*:/opt/amq/lib/extra/* org.apache.activemq.artemis.cli.Artemis producer --protocol=AMQP --url amqps://${BROKER_SERVICE_HOST}:${BROKER_SERVICE_PORT}\\?transport.trustStoreType=PEMCA\\&transport.trustStoreLocation=/app/tls/ca/ca.pem\\&transport.keyStoreType=PEMCFG\\&transport.keyStoreLocation=/app/tls/pem/tls.pemcfg --message-count 1 --destination queue://APP.JOBS';
+    const amqpConsumerCommand =
+      'exec java -classpath /opt/amq/lib/*:/opt/amq/lib/extra/* org.apache.activemq.artemis.cli.Artemis consumer --protocol=AMQP --url amqps://${BROKER_SERVICE_HOST}:${BROKER_SERVICE_PORT}\\?transport.trustStoreType=PEMCA\\&transport.trustStoreLocation=/app/tls/ca/ca.pem\\&transport.keyStoreType=PEMCFG\\&transport.keyStoreLocation=/app/tls/pem/tls.pemcfg --message-count 1 --destination queue://APP.JOBS --receive-timeout 30000';
+    const bindingSecretEnv = `
+        - name: BROKER_SERVICE_HOST
+          valueFrom:
+            secretKeyRef:
+              name: ${APP_NAME}-binding-secret
+              key: host
+        - name: BROKER_SERVICE_PORT
+          valueFrom:
+            secretKeyRef:
+              name: ${APP_NAME}-binding-secret
+              key: port`;
 
     console.log('\n✅ All verifications passed!');
 
@@ -228,18 +248,19 @@ spec:
   backoffLimit: 2
   template:
     spec:
-      activeDeadlineSeconds: 180
+      activeDeadlineSeconds: 300
       restartPolicy: Never
       containers:
       - name: producer
-        image: quay.io/arkmq-org/activemq-artemis-broker-kubernetes:artemis.2.40.0
+        image: quay.io/arkmq-org/arkmq-org-broker-kubernetes:artemis.2.40.0
         command:
         - "/bin/sh"
         - "-c"
-        - exec java -classpath /opt/amq/lib/*:/opt/amq/lib/extra/* org.apache.activemq.artemis.cli.Artemis producer --protocol=AMQP --url 'amqps://${SERVICE_NAME}:61616?transport.trustStoreType=PEMCA&transport.trustStoreLocation=/app/tls/ca/ca.pem&transport.keyStoreType=PEMCFG&transport.keyStoreLocation=/app/tls/pem/tls.pemcfg' --message-count 1 --destination queue://APP.JOBS
+        - ${JSON.stringify(amqpProducerCommand)}
         env:
         - name: JDK_JAVA_OPTIONS
           value: "-Djava.security.properties=/app/tls/pem/java.security"
+${bindingSecretEnv}
         volumeMounts:
         - name: trust
           mountPath: /app/tls/ca
@@ -250,7 +271,7 @@ spec:
       volumes:
       - name: trust
         secret:
-          secretName: activemq-artemis-manager-ca
+          secretName: arkmq-org-broker-manager-ca
       - name: cert
         secret:
           secretName: ${APP_NAME}-app-cert
@@ -277,18 +298,19 @@ spec:
   backoffLimit: 2
   template:
     spec:
-      activeDeadlineSeconds: 120
+      activeDeadlineSeconds: 180
       restartPolicy: Never
       containers:
       - name: consumer
-        image: quay.io/arkmq-org/activemq-artemis-broker-kubernetes:artemis.2.40.0
+        image: quay.io/arkmq-org/arkmq-org-broker-kubernetes:artemis.2.40.0
         command:
         - "/bin/sh"
         - "-c"
-        - exec java -classpath /opt/amq/lib/*:/opt/amq/lib/extra/* org.apache.activemq.artemis.cli.Artemis consumer --protocol=AMQP --url 'amqps://${SERVICE_NAME}:61616?transport.trustStoreType=PEMCA&transport.trustStoreLocation=/app/tls/ca/ca.pem&transport.keyStoreType=PEMCFG&transport.keyStoreLocation=/app/tls/pem/tls.pemcfg' --message-count 1 --destination queue://APP.JOBS --receive-timeout 30000
+        - ${JSON.stringify(amqpConsumerCommand)}
         env:
         - name: JDK_JAVA_OPTIONS
           value: "-Djava.security.properties=/app/tls/pem/java.security"
+${bindingSecretEnv}
         volumeMounts:
         - name: trust
           mountPath: /app/tls/ca
@@ -299,7 +321,7 @@ spec:
       volumes:
       - name: trust
         secret:
-          secretName: activemq-artemis-manager-ca
+          secretName: arkmq-org-broker-manager-ca
       - name: cert
         secret:
           secretName: ${APP_NAME}-app-cert
@@ -350,7 +372,7 @@ spec:
     expect(caIssuerExists).toBe('');
 
     // Verify Bundle is deleted
-    const bundleExists = kubectl('get bundle activemq-artemis-manager-ca -n cert-manager', {
+    const bundleExists = kubectl('get bundle arkmq-org-broker-manager-ca -n cert-manager', {
       ignoreError: true,
     });
     expect(bundleExists).toBe('');

--- a/playwright/fixtures/k8s.ts
+++ b/playwright/fixtures/k8s.ts
@@ -203,7 +203,7 @@ export function secretExists(secretName: string, namespace: string): boolean {
 }
 
 /**
- * Wait for a Kubernetes Job to complete successfully
+ * Wait for a Kubernetes Job to complete successfully.
  */
 export async function waitForJob(
   jobName: string,

--- a/scripts/chain-of-trust.js
+++ b/scripts/chain-of-trust.js
@@ -120,8 +120,8 @@ const resourceNames = {
   rootCert: 'root-cert',
   rootSecret: 'arkmq-root-cert-secret',
   caIssuer: 'broker-ca-issuer',
-  bundle: 'activemq-artemis-manager-ca',
-  operatorCert: 'activemq-artemis-manager-cert',
+  bundle: 'arkmq-org-broker-manager-ca',
+  operatorCert: 'arkmq-org-broker-manager-cert',
 };
 
 /**

--- a/scripts/prometheus-config.js
+++ b/scripts/prometheus-config.js
@@ -204,7 +204,7 @@ function generateServiceMonitor(options = {}) {
       options.brokerName || 'artemis-broker'
     }-hdls-svc.${namespace}.svc.cluster.local`,
     prometheusCertSecret = 'prometheus-cert',
-    caSecret = 'activemq-artemis-manager-ca',
+    caSecret = 'arkmq-org-broker-manager-ca',
   } = options;
 
   return `---

--- a/scripts/setup-pki.js
+++ b/scripts/setup-pki.js
@@ -201,7 +201,7 @@ spec:
 async function createTrustBundle(rootSecretName) {
   console.log(`📦 Creating trust bundle...`);
 
-  const bundleName = 'activemq-artemis-manager-ca';
+  const bundleName = 'arkmq-org-broker-manager-ca';
 
   const bundleYaml = `
 apiVersion: trust.cert-manager.io/v1alpha1
@@ -238,10 +238,10 @@ spec:
 async function createOperatorCert(namespace, caIssuerName) {
   console.log(`📦 Creating operator certificate in namespace: ${namespace}...`);
 
-  const operatorCertName = 'activemq-artemis-manager-cert';
+  const operatorCertName = 'arkmq-org-broker-manager-cert';
 
   // Wait for the CA secret to appear in the namespace
-  const bundleName = 'activemq-artemis-manager-ca';
+  const bundleName = 'arkmq-org-broker-manager-ca';
   console.log(`⏳ Waiting for CA secret to be distributed to namespace ${namespace}...`);
   await waitForSecret(namespace, bundleName);
 
@@ -283,7 +283,7 @@ async function createServiceCertificate(serviceName, namespace, caIssuerName) {
   );
 
   // Wait for the CA secret to appear in the namespace (distributed by trust-manager)
-  const bundleName = 'activemq-artemis-manager-ca';
+  const bundleName = 'arkmq-org-broker-manager-ca';
   console.log(`⏳ Waiting for CA secret to be distributed to namespace ${namespace}...`);
   await waitForSecret(namespace, bundleName);
 
@@ -300,6 +300,7 @@ spec:
   commonName: ${serviceName}
   dnsNames:
   - ${serviceName}
+  - ${serviceName}.${namespace}.svc.cluster.local
   - '*.${serviceName}-hdls-svc.${namespace}.svc.cluster.local'
   issuerRef:
     name: ${caIssuerName}
@@ -366,7 +367,7 @@ async function createPrometheusCertificate(namespace, caIssuerName) {
   );
 
   // Wait for the CA secret to appear in the namespace (distributed by trust-manager)
-  const bundleName = 'activemq-artemis-manager-ca';
+  const bundleName = 'arkmq-org-broker-manager-ca';
   console.log(`⏳ Waiting for CA secret to be distributed to namespace ${namespace}...`);
   await waitForSecret(namespace, bundleName);
 


### PR DESCRIPTION
- Raise certificate-management E2E timeout to 30 min to fix CRC CI 480000ms exceeded failures.
- Use BrokerApp binding secret host/port for mTLS jobs instead of hardcoded :61616.
- Rename PKI secrets from activemq-artemis-manager-* to arkmq-org-broker-manager-* (CA mount fix on CRC CI).
- Update producer/consumer job image to arkmq-org-broker-kubernetes after operator rename.

fixes: [issue#33](https://github.com/arkmq-org/arkmq-org-broker-operator-openshift-ui/issues/33)